### PR TITLE
chore: rename prebuilt binaries to expected names

### DIFF
--- a/impit-node/npm/darwin-arm64/package.json
+++ b/impit-node/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "impit-node-darwin-arm64",
+  "name": "impit-darwin-arm64",
   "version": "0.1.0",
   "os": [
     "darwin"

--- a/impit-node/npm/darwin-x64/package.json
+++ b/impit-node/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "impit-node-darwin-x64",
+  "name": "impit-darwin-x64",
   "version": "0.1.0",
   "os": [
     "darwin"

--- a/impit-node/npm/linux-arm64-gnu/package.json
+++ b/impit-node/npm/linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "impit-node-linux-arm64-gnu",
+  "name": "impit-linux-arm64-gnu",
   "version": "0.2.0",
   "repository": {
     "url": "https://github.com/apify/impit"

--- a/impit-node/npm/linux-arm64-musl/package.json
+++ b/impit-node/npm/linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "impit-node-linux-arm64-musl",
+  "name": "impit-linux-arm64-musl",
   "version": "0.2.0",
   "repository": {
     "url": "https://github.com/apify/impit"

--- a/impit-node/npm/linux-x64-gnu/package.json
+++ b/impit-node/npm/linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "impit-node-linux-x64-gnu",
+  "name": "impit-linux-x64-gnu",
   "version": "0.1.0",
   "os": [
     "linux"

--- a/impit-node/npm/linux-x64-musl/package.json
+++ b/impit-node/npm/linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "impit-node-linux-x64-musl",
+  "name": "impit-linux-x64-musl",
   "version": "0.1.0",
   "os": [
     "linux"

--- a/impit-node/npm/win32-arm64-msvc/package.json
+++ b/impit-node/npm/win32-arm64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "impit-node-win32-arm64-msvc",
+  "name": "impit-win32-arm64-msvc",
   "version": "0.1.0",
   "os": [
     "win32"

--- a/impit-node/npm/win32-x64-msvc/package.json
+++ b/impit-node/npm/win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "impit-node-win32-x64-msvc",
+  "name": "impit-win32-x64-msvc",
   "version": "0.1.0",
   "os": [
     "win32"


### PR DESCRIPTION
Reverts a mistake from #7 