### PR TITLE
fix(js): use replacement character on invalid decode

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -149,11 +149,10 @@ jobs:
     #       toolchain: ${{ matrix.toolchain }}
     #       args: "--locked --release"
     #     if: ${{ !matrix.platform.skip_tests }}
-      - name: Publish artifacts and release
-        uses: houseabsolute/actions-rust-release@v0.0.4
-        if: matrix.toolchain == 'stable'
-        with:
-          executable-name: impit-cli
-          target: ${{ matrix.platform.target }}
-          changes-file: ""
-          
+      # - name: Publish artifacts and release
+      #   uses: houseabsolute/actions-rust-release@v0.0.4
+      #   if: matrix.toolchain == 'stable'
+      #   with:
+      #     executable-name: impit-cli
+      #     target: ${{ matrix.platform.target }}
+      #     changes-file: ""

--- a/impit/src/response_parsing/mod.rs
+++ b/impit/src/response_parsing/mod.rs
@@ -100,7 +100,7 @@ pub fn decode(bytes: &[u8], encoding_prior_knowledge: Option<encoding::EncodingR
     }
 
     encoding
-        .decode(bytes, encoding::DecoderTrap::Strict)
+        .decode(bytes, encoding::DecoderTrap::Replace)
         .unwrap()
 }
 


### PR DESCRIPTION
When decoding incorrectly encoded content, the binding now panics and takes down the entire JS script. This change replaces the incorrect sequence with the U+FFFD replacement character (�) in the content. This is most often the desired behaviour. 