### PR TITLE
chore(js): do not create github release on npm release

### DIFF
--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -33,7 +33,7 @@
     "artifacts": "napi artifacts --dir ../artifacts --dist npm",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi prepublish -t npm",
+    "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "test": "vitest",
     "universal": "napi universal",
     "version": "napi version"


### PR DESCRIPTION
See [napi-rs docs](https://napi.rs/docs/cli/pre-publish). The current CI setup creates git tags manually, so the automatic git tags / releases from NAPI-RS just make it all messy. This PR disables those.