### PR TITLE
chore(js): add more tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,8 +2059,8 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
-source = "git+https://github.com/apify/rustls?branch=main#a4b1e4dbde034a81f0a690043c7606ccdc370740"
+version = "0.23.22"
+source = "git+https://github.com/apify/rustls?branch=main#aa89d94f2e7e12ac16a2722ed28f3864a2997f42"
 dependencies = [
  "aws-lc-rs",
  "brotli",

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -112,6 +112,15 @@ describe.each([
         // test that first 5 bytes of the response are the `<?xml` XML declaration
         t.expect(bytes.slice(0, 5)).toEqual(Buffer.from([0x3c, 0x3f, 0x78, 0x6d, 0x6c]));
         });
+
+        test('repeated response consumption works', async (t) => {
+        const response = await impit.fetch('https://httpbin.org/json');
+        const json = await response.json();
+        const text = await response.text();
+
+        t.expect(json?.slideshow?.author).toBe('Yours Truly');
+        t.expect(text).toContain('Yours Truly');
+        });
     });
 
     describe('Redirects', () => {

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -1,97 +1,152 @@
-import { test } from 'vitest';
+import { test, describe, expect } from 'vitest';
+import { Buffer } from 'node:buffer';
 
-import { HttpMethod, Impit } from '../index.js'
-const impit = new Impit();
+import { HttpMethod, Impit, Browser } from '../index.js';
 
-test('impit works', async (t) => {
-  const response = await impit.fetch('https://jindrich.bar');
+describe.each([
+    Browser.Chrome,
+    Browser.Firefox,
+    undefined,
+])(`Browser emulation [%s]`, (browser) => {
+    const impit = new Impit({ browser });
 
-  const text = await response.text();
-  
-  t.expect(text).toContain('barjin');
-})
+    describe('Basic requests', () => {
+        test.each([
+            'http://',
+            'https://',
+        ])('to an %s domain', async (protocol) => {
+            const response = impit.fetch(`${protocol}example.org`);
+            await expect(response).resolves.toBeTruthy();
+        });
 
-test('json method works', async (t) => {
-  const response = await impit.fetch('https://httpbin.org/json');
+        test('headers work', async (t) => {
+            const response = await impit.fetch(
+            'https://httpbin.org/headers',
+            {
+                headers: {
+                'Impit-Test': 'foo',
+                'Cookie': 'test=123; test2=456'
+                }
+            }
+            );
+            const json = await response.json();
 
-  const json = await response.json();
+            t.expect(json.headers?.['Impit-Test']).toBe('foo');
+        })
+    });
 
-  t.expect(json?.slideshow?.author).toBe('Yours Truly');
-})
+    describe('HTTP methods', () => {
+        test.each([
+            'GET',
+            'POST',
+            'PUT',
+            'DELETE',
+            'PATCH',
+            'HEAD',
+            'OPTIONS'
+        ] as HttpMethod[])('%s', async (method) => {
+            const response = impit.fetch(`https://example.org`, {
+                method
+            });
+            await expect(response).resolves.toBeTruthy();
+        });
+    });
 
-test('headers work', async (t) => {
-  const response = await impit.fetch(
-    'https://httpbin.org/headers', 
-    { 
-      headers: { 
-        'Impit-Test': 'foo',
-        'Cookie': 'test=123; test2=456'
-      } 
-    }
-  );
-  const json = await response.json();
+    describe('Request body', () => {
+        test('passing string body', async (t) => {
+            const response = await impit.fetch(
+            'https://httpbin.org/post',
+            {
+                    method: HttpMethod.Post,
+                    body: '{"Impit-Test":"foořžš"}',
+                    headers: { 'Content-Type': 'application/json' }
+            }
+            );
+            const json = await response.json();
 
-  t.expect(json.headers?.['Impit-Test']).toBe('foo');
-})
+            t.expect(json.data).toEqual('{"Impit-Test":"foořžš"}');
+        });
 
-test('string request body works', async (t) => {
-  const response = await impit.fetch(
-    'https://httpbin.org/post', 
-    { 
-      method: HttpMethod.Post,
-      body: '{"Impit-Test":"foořžš"}',
-      headers: { 'Content-Type': 'application/json' }
-    }
-  );
-  const json = await response.json();
+        test('passing binary body', async (t) => {
+            const response = await impit.fetch(
+                'https://httpbin.org/post',
+                {
+                    method: HttpMethod.Post,
+                    body: Uint8Array.from([0x49, 0x6d, 0x70, 0x69, 0x74, 0x2d, 0x54, 0x65, 0x73, 0x74, 0x3a, 0x66, 0x6f, 0x6f, 0xc5, 0x99, 0xc5, 0xbe, 0xc5, 0xa1]),
+                    headers: { 'Content-Type': 'application/json' }
+                }
+            );
+            const json = await response.json();
 
-  t.expect(json.data).toEqual('{"Impit-Test":"foořžš"}');
-});
+            t.expect(json.data).toEqual('Impit-Test:foořžš');
+        });
 
-test('binary request body works', async (t) => {
-  const response = await impit.fetch(
-    'https://httpbin.org/post', 
-    { 
-      method: HttpMethod.Post,
-      body: Uint8Array.from([0x49, 0x6d, 0x70, 0x69, 0x74, 0x2d, 0x54, 0x65, 0x73, 0x74, 0x3a, 0x66, 0x6f, 0x6f, 0xc5, 0x99, 0xc5, 0xbe, 0xc5, 0xa1]),
-      headers: { 'Content-Type': 'application/json' }
-    }
-  );
-  const json = await response.json();
+        test.each(['post', 'put', 'patch'])('using %s method', async (method) => {
+            const response = impit.fetch('https://example.org', {
+                method: method.toUpperCase() as HttpMethod,
+                body: 'foo'
+            });
+            await expect(response).resolves.toBeTruthy();
+        });
+    });
 
-  t.expect(json.data).toEqual('Impit-Test:foořžš');
-});
+    describe('Response parsing', () => {
+        test('.text() method works', async (t) => {
+        const response = await impit.fetch('https://httpbin.org/html');
+        const text = await response.text();
 
-test('redirects work by default', async (t) => {
-  const response = await impit.fetch(
-    'https://httpbin.org/absolute-redirect/1', 
-  );
+        t.expect(text).toContain('Herman Melville');
+        });
 
-  t.expect(response.status).toBe(200);
-});
+        test('.json() method works', async (t) => {
+        const response = await impit.fetch('https://httpbin.org/json');
+        const json = await response.json();
 
-test('disabling redirects works', async (t) => {
-  const impit = new Impit({
-    followRedirects: false
-  });
+        t.expect(json?.slideshow?.author).toBe('Yours Truly');
+        });
 
-  const response = await impit.fetch(
-    'https://httpbin.org/absolute-redirect/1', 
-  );
+        test('.bytes() method works', async (t) => {
+        const response = await impit.fetch('https://httpbin.org/xml');
+        const bytes = await response.bytes();
 
-  t.expect(response.status).toBe(302);
-  t.expect(response.headers['location']).toBe('http://httpbin.org/get');
-});
+        // test that first 5 bytes of the response are the `<?xml` XML declaration
+        t.expect(bytes.slice(0, 5)).toEqual(Buffer.from([0x3c, 0x3f, 0x78, 0x6d, 0x6c]));
+        });
+    });
 
-test('limiting redirects works', async (t) => {
-  const impit = new Impit({
-    followRedirects: true,
-    maxRedirects: 1
-  });
+    describe('Redirects', () => {
+        test('redirects work by default', async (t) => {
+            const response = await impit.fetch(
+                'https://httpbin.org/absolute-redirect/1',
+            );
 
-  const response = impit.fetch(
-    'https://httpbin.org/absolute-redirect/2', 
-  );
+            t.expect(response.status).toBe(200);
+        });
 
-  t.expect(response).rejects.toThrowError('TooManyRedirects');
+        test('disabling redirects', async (t) => {
+            const impit = new Impit({
+                followRedirects: false
+            });
+
+            const response = await impit.fetch(
+                'https://httpbin.org/absolute-redirect/1',
+            );
+
+            t.expect(response.status).toBe(302);
+            t.expect(response.headers['location']).toBe('http://httpbin.org/get');
+        });
+
+        test('limiting redirects', async (t) => {
+            const impit = new Impit({
+                followRedirects: true,
+                maxRedirects: 1
+            });
+
+            const response = impit.fetch(
+                'https://httpbin.org/absolute-redirect/2',
+            );
+
+            await t.expect(response).rejects.toThrowError('TooManyRedirects');
+        });
+    })
 });


### PR DESCRIPTION
The Node `impit` tests were rather minimalistic and targetting only the most basic use-cases.

This PR adds more test cases and a matrix of different HTTP methods / impersonated browsers to run the tests with.