### PR TITLE
chore: conform to the new NAPI CLI

### DIFF
--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -35,7 +35,7 @@
     "artifacts": "napi artifacts --dir ../artifacts --dist npm",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
+    "prepublishOnly": "napi prepublish -t npm",
     "test": "vitest",
     "universal": "napi universal",
     "version": "napi version"


### PR DESCRIPTION
Uses the new (canary) `@napi-rs/cli` arguments. GH Release creation is now opt-in with the `--gh-release` flag.