### PR TITLE
chore: make HTTPBin tests more stable

### DIFF
--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -36,7 +36,7 @@
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm --no-gh-release",
-    "test": "vitest",
+    "test": "vitest --retry=3",
     "universal": "napi universal",
     "version": "napi version"
   },

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -19,9 +19,9 @@ function getHttpBinUrl(path: string, https?: boolean): string {
 
 beforeAll(async () => {
     // Warms up the httpbin instance, so that the first tests don't timeout.
-    // Has a longer timeout itself (5s vs 10s) to avoid flakiness.
+    // Has a longer timeout itself (5s vs 30s) to avoid flakiness.
     await fetch(getHttpBinUrl('/get'));
-}, 10_000);
+}, 30e3);
 
 describe.each([
     Browser.Chrome,


### PR DESCRIPTION
Adds retries and longer timeouts, which should help with the flaky HTTPBin tests.