### PR TITLE
chore(ci): use `yarn@v4` in NPM publish step

### DIFF
--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -41,6 +41,15 @@ jobs:
             uses: actions/setup-node@v4
             with:
               node-version: 20
+
+          - name: Enable Corepack
+            run: |
+              corepack enable
+              corepack prepare yarn@stable --activate
+
+          - name: Activate cache for Node.js
+            uses: actions/setup-node@v4
+            with:
               cache: yarn
               cache-dependency-path: impit-node/yarn.lock
 


### PR DESCRIPTION
Fixes the NPM release pipeline (failing with `yarn` version mismatch now)