### PR TITLE
feat(js): add `.url` field to `impit-node` Response

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -234,7 +234,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: docker run -e CI=1 -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }} --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim corepack enable && yarn --cwd impit-node test
+        run: docker run -e CI=1 -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }} --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim sh -c "corepack enable && yarn --cwd impit-node test"
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:

--- a/impit-node/index.d.ts
+++ b/impit-node/index.d.ts
@@ -12,6 +12,7 @@ export declare class ImpitResponse {
   statusText: string
   headers: Record<string, string>
   ok: boolean
+  url: string
   bytes(this: object): Promise<Uint8Array>
   text(this: object): Promise<String>
   json(this: object): Promise<any>

--- a/impit-node/src/response.rs
+++ b/impit-node/src/response.rs
@@ -16,6 +16,7 @@ pub struct ImpitResponse {
   pub status_text: String,
   pub headers: HashMap<String, String>,
   pub ok: bool,
+  pub url: String,
 }
 
 #[napi]
@@ -33,12 +34,15 @@ impl ImpitResponse {
       .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap().to_string()))
       .collect();
     let ok = response.status().is_success();
+    let url = response.url().to_string();
+
     Self {
       inner: RefCell::new(Some(response)),
       status,
       status_text,
       headers,
       ok,
+      url,
     }
   }
 

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -160,7 +160,7 @@ describe.each([
             );
 
             t.expect(response.status).toBe(200);
-            t.expect(response.url).toBe(getHttpBinUrl('/get', false));
+            t.expect(response.url).toBe(getHttpBinUrl('/get', true));
         });
 
         test('disabling redirects', async (t) => {

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -160,6 +160,7 @@ describe.each([
             );
 
             t.expect(response.status).toBe(200);
+            t.expect(response.url).toBe(getHttpBinUrl('/get', false));
         });
 
         test('disabling redirects', async (t) => {
@@ -173,6 +174,7 @@ describe.each([
 
             t.expect(response.status).toBe(302);
             t.expect(response.headers['location']).toBe(getHttpBinUrl('/get', false));
+            t.expect(response.url).toBe(getHttpBinUrl('/absolute-redirect/1', true));
         });
 
         test('limiting redirects', async (t) => {

--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -1941,13 +1941,74 @@ __metadata:
   languageName: node
   linkType: hard
 
+"impit-darwin-arm64@npm:0.2.0":
+  version: 0.2.0
+  resolution: "impit-darwin-arm64@npm:0.2.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"impit-darwin-x64@npm:0.2.0":
+  version: 0.2.0
+  resolution: "impit-darwin-x64@npm:0.2.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"impit-linux-x64-gnu@npm:0.2.0":
+  version: 0.2.0
+  resolution: "impit-linux-x64-gnu@npm:0.2.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"impit-linux-x64-musl@npm:0.2.0":
+  version: 0.2.0
+  resolution: "impit-linux-x64-musl@npm:0.2.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"impit-win32-arm64-msvc@npm:0.2.0":
+  version: 0.2.0
+  resolution: "impit-win32-arm64-msvc@npm:0.2.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"impit-win32-x64-msvc@npm:0.2.0":
+  version: 0.2.0
+  resolution: "impit-win32-x64-msvc@npm:0.2.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "impit@workspace:.":
   version: 0.0.0-use.local
   resolution: "impit@workspace:."
   dependencies:
     "@napi-rs/cli": "npm:^3.0.0-alpha.70"
     "@types/node": "npm:^22.13.1"
+    impit-darwin-arm64: "npm:0.2.0"
+    impit-darwin-x64: "npm:0.2.0"
+    impit-linux-x64-gnu: "npm:0.2.0"
+    impit-linux-x64-musl: "npm:0.2.0"
+    impit-win32-arm64-msvc: "npm:0.2.0"
+    impit-win32-x64-msvc: "npm:0.2.0"
     vitest: "npm:^3.0.5"
+  dependenciesMeta:
+    impit-darwin-arm64:
+      optional: true
+    impit-darwin-x64:
+      optional: true
+    impit-linux-x64-gnu:
+      optional: true
+    impit-linux-x64-musl:
+      optional: true
+    impit-win32-arm64-msvc:
+      optional: true
+    impit-win32-x64-msvc:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Adds [Response.url](https://developer.mozilla.org/en-US/docs/Web/API/Response/url) property to the `ImpitResponse` struct / object.