### PR TITLE
fix(js): reenable HTTP/3 features in JS bindings

### DIFF
--- a/impit-node/Cargo.toml
+++ b/impit-node/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
-napi = { version = "3.0.0-alpha.27", default-features = false, features = ["napi4", "async", "web_stream"] }
+napi = { version = "3.0.0-alpha.27", default-features = false, features = ["napi4", "async", "web_stream", "tokio_rt"] }
 napi-derive = "3.0.0-alpha.25"
 impit = { path="../impit" }
 rustls = { version="0.23.16" }

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -53,6 +53,24 @@ describe.each([
 
             t.expect(json.headers?.['Impit-Test']).toBe('foo');
         })
+
+        test('http3 works', async (t) => {
+            const impit = new Impit({
+                http3: true,
+                browser,
+            })
+
+            const response = await impit.fetch(
+                'https://curl.se',
+                {
+                    forceHttp3: true,
+                }
+            );
+
+            const text = await response.text();
+
+            t.expect(text).toContain('curl');
+        })
     });
 
     describe('HTTP methods', () => {

--- a/impit/src/http_headers/statics.rs
+++ b/impit/src/http_headers/statics.rs
@@ -35,7 +35,6 @@ pub static FIREFOX_HEADERS: &[(&str, &str)] = &[
     ("sec-fetch-mode", "navigate"),
     ("sec-fetch-site", "none"),
     ("sec-fetch-user", "?1"),
-    ("Connection", "keep-alive"),
     ("Upgrade-Insecure-Requests", "1"),
     ("Priority", "u=0, i"),
 ];


### PR DESCRIPTION
Recent package updates might have broken the `http3` feature in Node.JS bindings. This PR solves the underlying problems by building the reqwest's `Client` from within the `napi-rs`-managed `tokio` runtime. 

Adds tests for `http3` usage from Node bindings.

Removes problematic Firefox header (`Connection` is not allowed in HTTP2 and HTTP3 requests or responses and together with `forceHttp3` was causing panics inside the Rust code). 