### PR TITLE
fix(js): allow `impit` usage from ESM

### DIFF
--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -1,4 +1,4 @@
-const exports = require('./index.js');
+const native = require('./index.js');
 
 class ResponsePatches {
     static async text() {
@@ -7,7 +7,7 @@ class ResponsePatches {
     }
 }
 
-class Impit extends exports.Impit {
+class Impit extends native.Impit {
     async fetch(url, options) {
         const originalResponse = await super.fetch(url, options);
 
@@ -19,8 +19,8 @@ class Impit extends exports.Impit {
     }
 }
 
-exports.ImpitResponse = Response;
-exports.Impit = Impit;
+native.ImpitResponse = Response;
+native.Impit = Impit;
 
-module.exports = exports;
+module.exports = native;
 

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -45,11 +45,11 @@
   "packageManager": "yarn@4.6.0",
   "description": "Impit for JavaScript",
   "optionalDependencies": {
+    "impit-darwin-arm64": "0.2.3",
     "impit-darwin-x64": "0.2.3",
     "impit-linux-x64-gnu": "0.2.3",
-    "impit-win32-x64-msvc": "0.2.3",
-    "impit-darwin-arm64": "0.2.3",
+    "impit-linux-x64-musl": "0.2.3",
     "impit-win32-arm64-msvc": "0.2.3",
-    "impit-linux-x64-musl": "0.2.3"
+    "impit-win32-x64-msvc": "0.2.3"
   }
 }

--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -2358,44 +2358,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.2.1":
-  version: 0.2.1
-  resolution: "impit-darwin-arm64@npm:0.2.1"
+"impit-darwin-arm64@npm:0.2.3":
+  version: 0.2.3
+  resolution: "impit-darwin-arm64@npm:0.2.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.2.1":
-  version: 0.2.1
-  resolution: "impit-darwin-x64@npm:0.2.1"
+"impit-darwin-x64@npm:0.2.3":
+  version: 0.2.3
+  resolution: "impit-darwin-x64@npm:0.2.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.2.1":
-  version: 0.2.1
-  resolution: "impit-linux-x64-gnu@npm:0.2.1"
+"impit-linux-x64-gnu@npm:0.2.3":
+  version: 0.2.3
+  resolution: "impit-linux-x64-gnu@npm:0.2.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.2.1":
-  version: 0.2.1
-  resolution: "impit-linux-x64-musl@npm:0.2.1"
+"impit-linux-x64-musl@npm:0.2.3":
+  version: 0.2.3
+  resolution: "impit-linux-x64-musl@npm:0.2.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.2.1":
-  version: 0.2.1
-  resolution: "impit-win32-arm64-msvc@npm:0.2.1"
+"impit-win32-arm64-msvc@npm:0.2.3":
+  version: 0.2.3
+  resolution: "impit-win32-arm64-msvc@npm:0.2.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.2.1":
-  version: 0.2.1
-  resolution: "impit-win32-x64-msvc@npm:0.2.1"
+"impit-win32-x64-msvc@npm:0.2.3":
+  version: 0.2.3
+  resolution: "impit-win32-x64-msvc@npm:0.2.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2408,12 +2408,12 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^22.13.1"
     express: "npm:^4.21.2"
-    impit-darwin-arm64: "npm:0.2.1"
-    impit-darwin-x64: "npm:0.2.1"
-    impit-linux-x64-gnu: "npm:0.2.1"
-    impit-linux-x64-musl: "npm:0.2.1"
-    impit-win32-arm64-msvc: "npm:0.2.1"
-    impit-win32-x64-msvc: "npm:0.2.1"
+    impit-darwin-arm64: "npm:0.2.3"
+    impit-darwin-x64: "npm:0.2.3"
+    impit-linux-x64-gnu: "npm:0.2.3"
+    impit-linux-x64-musl: "npm:0.2.3"
+    impit-win32-arm64-msvc: "npm:0.2.3"
+    impit-win32-x64-msvc: "npm:0.2.3"
     vitest: "npm:^3.0.5"
   dependenciesMeta:
     impit-darwin-arm64:


### PR DESCRIPTION
Renames native code import to mitigate naming collision with global `exports`.