### PR TITLE
fix(js): enable ESM named imports from `impit` packages

### DIFF
--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -19,8 +19,9 @@ class Impit extends native.Impit {
     }
 }
 
-native.ImpitResponse = Response;
-native.Impit = Impit;
-
-module.exports = native;
+module.exports.Impit = Impit
+module.exports.ImpitWrapper = native.ImpitWrapper
+module.exports.ImpitResponse = native.ImpitResponse
+module.exports.Browser = native.Browser
+module.exports.HttpMethod = native.HttpMethod
 

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -3,7 +3,6 @@ import { test, describe, expect, beforeAll, afterAll } from 'vitest';
 import { HttpMethod, Impit, Browser } from '../index.wrapper.js';
 import { Server } from 'http';
 import { routes, runServer } from './mock.server.js';
-import { get } from 'express/lib/response.js';
 
 function getHttpBinUrl(path: string, https?: boolean): string {
     https ??= true;


### PR DESCRIPTION
Lists the "named" exports from the `impit` package verbatim so they can be imported with

```typescript
import { Impit } from 'impit'; 
```

from ESM packages without causing the following error:

```
import { Impit } from "impit";
         ^^^^^
SyntaxError: Named export 'Impit' not found. The requested module 'impit' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'impit';
const { Impit } = pkg;
```