### PR TITLE
chore(ci): upload artifacts on CLI build

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -141,18 +141,21 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           args: "--locked --release --manifest-path impit-cli/Cargo.toml"
           strip: true
-    #   - name: Run tests
-    #     uses: houseabsolute/actions-rust-cross@v0
-    #     with:
-    #       command: "test"
-    #       target: ${{ matrix.platform.target }}
-    #       toolchain: ${{ matrix.toolchain }}
-    #       args: "--locked --release"
-    #     if: ${{ !matrix.platform.skip_tests }}
-      # - name: Publish artifacts and release
-      #   uses: houseabsolute/actions-rust-release@v0.0.4
-      #   if: matrix.toolchain == 'stable'
-      #   with:
-      #     executable-name: impit-cli
-      #     target: ${{ matrix.platform.target }}
-      #     changes-file: ""
+
+      - name: Run tests
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "test"
+          target: ${{ matrix.platform.target }}
+          toolchain: ${{ matrix.toolchain }}
+          args: "--locked --release"
+        if: ${{ !matrix.platform.skip_tests }}
+
+      - name: Publish artifacts
+        uses: houseabsolute/actions-rust-release@v0.0.4
+        if: matrix.toolchain == 'stable'
+        with:
+          executable-name: impit-cli
+          target: ${{ matrix.platform.target }}
+          changes-file: ""
+          release-tag-prefix: cli

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - "master"
-    tags-ignore:
-      - "impit-cli-*"
+    tags:
+      - "cli-*"
     paths:
       - "impit-cli/**"
       - "impit/**"
@@ -14,6 +14,8 @@ on:
     paths:
       - "impit-cli/**"
       - "impit/**"
+      - Cargo.toml
+      - Cargo.lock
   workflow_dispatch:
 
 env:
@@ -153,7 +155,7 @@ jobs:
 
       - name: Publish artifacts
         uses: houseabsolute/actions-rust-release@v0.0.4
-        if: matrix.toolchain == 'stable'
+        if: matrix.toolchain == 'stable' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         with:
           executable-name: impit-cli
           target: ${{ matrix.platform.target }}


### PR DESCRIPTION
Reenable [uploading run artifacts](https://github.com/houseabsolute/actions-rust-release/blob/48ce35fb40c3dab00791a3d6c485022341354c44/action.yml#L148) for the CLI build action. Change the required tag prefix to mitigate triggering CLI builds on 