### PR TITLE
chore(ci): run relevant tests in CLI workflow

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -150,7 +150,7 @@ jobs:
           command: "test"
           target: ${{ matrix.platform.target }}
           toolchain: ${{ matrix.toolchain }}
-          args: "--locked --release"
+          args: "--locked --release --manifest-path impit-cli/Cargo.toml"
         if: ${{ !matrix.platform.skip_tests }}
 
       - name: Publish artifacts

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -8,9 +8,13 @@ name: "[impit-python] Test & Build"
 on:
   push:
     branches:
-      - master
+        - "master"
     tags:
-      - '*'
+        - "py-*"
+    paths:
+        - "impit-python/**"
+        - "impit/**"
+        - 'Cargo.*'
   pull_request:
     paths:
         - 'impit-python/**'


### PR DESCRIPTION
Runs only CLI-related tests in the CLI workflow and disables time-consuming builds of Python bindings if there were no changes to the relevant code.