### PR TITLE
feat: use `thiserror` for better error handling DX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "scraper",
+ "thiserror 2.0.12",
  "tokio",
  "url",
  "webpki-roots",
@@ -2237,7 +2238,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "rustls",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -2256,7 +2257,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2846,11 +2847,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2866,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/impit/Cargo.toml
+++ b/impit/Cargo.toml
@@ -14,6 +14,7 @@ num-bigint = "0.4.6"
 reqwest = { version = "0.12.9", features = ["json", "gzip", "brotli", "zstd", "deflate", "rustls-tls", "http3", "cookies", "stream"] }
 rustls = { version="0.23.16", features=["impit"] }
 scraper = "0.22.0"
+thiserror = "2.0.12"
 tokio = { version="1.40.0", features = ["full"] }
 url = "2.5.2"
 webpki-roots = "0.26.6"

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -1,7 +1,7 @@
 use log::debug;
 use reqwest::{Method, Response, Version};
-use thiserror::Error;
 use std::{str::FromStr, time::Duration};
+use thiserror::Error;
 use url::Url;
 
 use crate::{

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -1,5 +1,6 @@
 use log::debug;
 use reqwest::{Method, Response, Version};
+use thiserror::Error;
 use std::{str::FromStr, time::Duration};
 use url::Url;
 
@@ -11,18 +12,18 @@ use crate::{
 ///
 /// The `ErrorType` enum is used to represent the different types of errors that can occur when making requests.
 /// The `RequestError` variant is used to wrap the `reqwest::Error` type.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ErrorType {
-    /// The URL couldn't be parsed.
+    #[error("The URL couldn't be parsed.")]
     UrlParsingError,
-    /// The URL is missing the hostname.
+    #[error("The URL is missing the hostname.")]
     UrlMissingHostnameError,
-    /// The URL uses an unsupported protocol.
+    #[error("The URL uses an unsupported protocol. Currently, only HTTP and HTTPS are supported.")]
     UrlProtocolError,
-    /// The request was made with `http3_prior_knowledge`, but HTTP/3 usage wasn't enabled.
+    #[error("The request was made with http3_prior_knowledge, but HTTP/3 usage wasn't enabled.")]
     Http3Disabled,
-    /// `reqwest::Error` variant. See the nested error for more details.
-    RequestError(reqwest::Error),
+    #[error(transparent)]
+    RequestError(#[from] reqwest::Error),
 }
 
 /// Impit is the main struct used to make (impersonated) requests.


### PR DESCRIPTION
Adds `std::error::Error` implementation with `thiserror`. This should improve the developer experience and error messages across the monorepo.

Closes #84 