### PR TITLE
fix(js): bundle native binary in `linux-arm64` packages

### DIFF
--- a/impit-node/npm/linux-arm64-gnu/package.json
+++ b/impit-node/npm/linux-arm64-gnu/package.json
@@ -11,9 +11,9 @@
   "cpu": [
     "arm64"
   ],
-  "main": "impit.linux-arm64-gnu.node",
+  "main": "impit-node.linux-arm64-gnu.node",
   "files": [
-    "impit.linux-arm64-gnu.node"
+    "impit-node.linux-arm64-gnu.node"
   ],
   "license": "MIT",
   "engines": {

--- a/impit-node/npm/linux-arm64-musl/package.json
+++ b/impit-node/npm/linux-arm64-musl/package.json
@@ -11,9 +11,9 @@
   "cpu": [
     "arm64"
   ],
-  "main": "impit.linux-arm64-musl.node",
+  "main": "impit-node.linux-arm64-musl.node",
   "files": [
-    "impit.linux-arm64-musl.node"
+    "impit-node.linux-arm64-musl.node"
   ],
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Followup to #94 , the `impit-linux-arm64-(gnu|musl)` published packages didn't have the native binary included due to naming mismatch.