### PR TITLE
feat(py): allow passing binary body to the `data` parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-stream",
+ "urlencoding",
 ]
 
 [[package]]
@@ -3130,6 +3131,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/impit-python/Cargo.toml
+++ b/impit-python/Cargo.toml
@@ -18,6 +18,7 @@ bytes = "1.9.0"
 pyo3 = { version = "0.23", features = ["extension-module"] }
 pyo3-async-runtimes = { version = "0.23", features = ["attributes", "async-std-runtime", "tokio-runtime"] }
 openssl = { version = "*", features = ["vendored"] }
+urlencoding = "2.1.3"
 
 [build-dependencies]
 napi-build = "2.1.4"

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -231,31 +231,35 @@ impl AsyncClient {
         method: &str,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<RequestBody>,
+        mut data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
     ) -> Result<pyo3::Bound<'python, PyAny>, PyErr> {
         let mut headers = headers.clone();
 
-        let body: Vec<u8> = match content {
-            Some(content) => content,
-            None => match data {
-                Some(data) => {
-                    match data {
-                        RequestBody::Bytes(bytes) => bytes,
-                        RequestBody::Form(form) => {
-                            headers.get_or_insert_with(HashMap::new).insert(
-                                "Content-Type".to_string(),
-                                "application/x-www-form-urlencoded".to_string(),
-                            );
-                            form_to_bytes(form)
-                        },
-                        RequestBody::CatchAll(e) => panic!("Unsupported data type in request body: {:#?}", e),
-                    }
-                }
-                None => Vec::new(),
+        match content {
+            Some(content) => {
+                data = Some(RequestBody::Bytes(content));
             },
+            None => {},
+        }
+
+        let body: Vec<u8> = match data {
+            Some(data) => {
+                match data {
+                    RequestBody::Bytes(bytes) => bytes,
+                    RequestBody::Form(form) => {
+                        headers.get_or_insert_with(HashMap::new).insert(
+                            "Content-Type".to_string(),
+                            "application/x-www-form-urlencoded".to_string(),
+                        );
+                        form_to_bytes(form)
+                    },
+                    RequestBody::CatchAll(e) => panic!("Unsupported data type in request body: {:#?}", e),
+                }
+            }
+            None => Vec::new(),
         };
 
         let options = RequestOptions {

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -238,27 +238,24 @@ impl AsyncClient {
     ) -> Result<pyo3::Bound<'python, PyAny>, PyErr> {
         let mut headers = headers.clone();
 
-        match content {
-            Some(content) => {
-                data = Some(RequestBody::Bytes(content));
-            },
-            None => {},
+        if let Some(content) = content {
+            data = Some(RequestBody::Bytes(content));
         }
 
         let body: Vec<u8> = match data {
-            Some(data) => {
-                match data {
-                    RequestBody::Bytes(bytes) => bytes,
-                    RequestBody::Form(form) => {
-                        headers.get_or_insert_with(HashMap::new).insert(
-                            "Content-Type".to_string(),
-                            "application/x-www-form-urlencoded".to_string(),
-                        );
-                        form_to_bytes(form)
-                    },
-                    RequestBody::CatchAll(e) => panic!("Unsupported data type in request body: {:#?}", e),
+            Some(data) => match data {
+                RequestBody::Bytes(bytes) => bytes,
+                RequestBody::Form(form) => {
+                    headers.get_or_insert_with(HashMap::new).insert(
+                        "Content-Type".to_string(),
+                        "application/x-www-form-urlencoded".to_string(),
+                    );
+                    form_to_bytes(form)
                 }
-            }
+                RequestBody::CatchAll(e) => {
+                    panic!("Unsupported data type in request body: {:#?}", e)
+                }
+            },
             None => Vec::new(),
         };
 

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -7,7 +7,7 @@ use impit::{
 };
 use pyo3::prelude::*;
 
-use crate::response;
+use crate::{request::{form_to_bytes, RequestBody}, response};
 
 #[pyclass]
 pub(crate) struct Client {
@@ -68,7 +68,7 @@ impl Client {
         &mut self,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -81,7 +81,7 @@ impl Client {
         &mut self,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -94,7 +94,7 @@ impl Client {
         &mut self,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -107,7 +107,7 @@ impl Client {
         &mut self,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -120,7 +120,7 @@ impl Client {
         &mut self,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -133,7 +133,7 @@ impl Client {
         &mut self,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -146,7 +146,7 @@ impl Client {
         &mut self,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -159,7 +159,7 @@ impl Client {
         &mut self,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -173,7 +173,7 @@ impl Client {
         method: &str,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<HashMap<String, String>>,
+        data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
@@ -184,19 +184,17 @@ impl Client {
             Some(content) => content,
             None => match data {
                 Some(data) => {
-                    let mut body = Vec::new();
-                    for (key, value) in data {
-                        body.extend_from_slice(key.as_bytes());
-                        body.extend_from_slice(b"=");
-                        body.extend_from_slice(value.as_bytes());
-                        body.extend_from_slice(b"&");
+                    match data {
+                        RequestBody::Bytes(bytes) => bytes,
+                        RequestBody::Form(form) => {
+                            headers.get_or_insert_with(HashMap::new).insert(
+                                "Content-Type".to_string(),
+                                "application/x-www-form-urlencoded".to_string(),
+                            );
+                            form_to_bytes(form)
+                        },
+                        RequestBody::CatchAll(e) => panic!("Unsupported data type in request body: {:#?}", e),
                     }
-                    headers.get_or_insert_with(HashMap::new).insert(
-                        "Content-Type".to_string(),
-                        "application/x-www-form-urlencoded".to_string(),
-                    );
-
-                    body
                 }
                 None => Vec::new(),
             },

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -7,7 +7,10 @@ use impit::{
 };
 use pyo3::prelude::*;
 
-use crate::{request::{form_to_bytes, RequestBody}, response};
+use crate::{
+    request::{form_to_bytes, RequestBody},
+    response,
+};
 
 #[pyclass]
 pub(crate) struct Client {
@@ -180,27 +183,24 @@ impl Client {
     ) -> response::ImpitPyResponse {
         let mut headers = headers.clone();
 
-        match content {
-            Some(content) => {
-                data = Some(RequestBody::Bytes(content));
-            },
-            None => {},
+        if let Some(content) = content {
+            data = Some(RequestBody::Bytes(content));
         }
 
         let body: Vec<u8> = match data {
-            Some(data) => {
-                match data {
-                    RequestBody::Bytes(bytes) => bytes,
-                    RequestBody::Form(form) => {
-                        headers.get_or_insert_with(HashMap::new).insert(
-                            "Content-Type".to_string(),
-                            "application/x-www-form-urlencoded".to_string(),
-                        );
-                        form_to_bytes(form)
-                    },
-                    RequestBody::CatchAll(e) => panic!("Unsupported data type in request body: {:#?}", e),
+            Some(data) => match data {
+                RequestBody::Bytes(bytes) => bytes,
+                RequestBody::Form(form) => {
+                    headers.get_or_insert_with(HashMap::new).insert(
+                        "Content-Type".to_string(),
+                        "application/x-www-form-urlencoded".to_string(),
+                    );
+                    form_to_bytes(form)
                 }
-            }
+                RequestBody::CatchAll(e) => {
+                    panic!("Unsupported data type in request body: {:#?}", e)
+                }
+            },
             None => Vec::new(),
         };
 

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -173,31 +173,35 @@ impl Client {
         method: &str,
         url: String,
         content: Option<Vec<u8>>,
-        data: Option<RequestBody>,
+        mut data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<f64>,
         force_http3: Option<bool>,
     ) -> response::ImpitPyResponse {
         let mut headers = headers.clone();
 
-        let body: Vec<u8> = match content {
-            Some(content) => content,
-            None => match data {
-                Some(data) => {
-                    match data {
-                        RequestBody::Bytes(bytes) => bytes,
-                        RequestBody::Form(form) => {
-                            headers.get_or_insert_with(HashMap::new).insert(
-                                "Content-Type".to_string(),
-                                "application/x-www-form-urlencoded".to_string(),
-                            );
-                            form_to_bytes(form)
-                        },
-                        RequestBody::CatchAll(e) => panic!("Unsupported data type in request body: {:#?}", e),
-                    }
-                }
-                None => Vec::new(),
+        match content {
+            Some(content) => {
+                data = Some(RequestBody::Bytes(content));
             },
+            None => {},
+        }
+
+        let body: Vec<u8> = match data {
+            Some(data) => {
+                match data {
+                    RequestBody::Bytes(bytes) => bytes,
+                    RequestBody::Form(form) => {
+                        headers.get_or_insert_with(HashMap::new).insert(
+                            "Content-Type".to_string(),
+                            "application/x-www-form-urlencoded".to_string(),
+                        );
+                        form_to_bytes(form)
+                    },
+                    RequestBody::CatchAll(e) => panic!("Unsupported data type in request body: {:#?}", e),
+                }
+            }
+            None => Vec::new(),
         };
 
         let options = RequestOptions {

--- a/impit-python/src/lib.rs
+++ b/impit-python/src/lib.rs
@@ -3,8 +3,10 @@ use pyo3::prelude::*;
 mod async_client;
 mod client;
 mod response;
+mod request;
 use async_client::AsyncClient;
 use client::Client;
+use request::RequestBody;
 
 use std::collections::HashMap;
 
@@ -21,7 +23,7 @@ fn impit(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
                 fn $name(
                     url: String,
                     content: Option<Vec<u8>>,
-                    data: Option<HashMap<String, String>>,
+                    data: Option<RequestBody>,
                     headers: Option<HashMap<String, String>>,
                     timeout: Option<f64>,
                     force_http3: Option<bool>,

--- a/impit-python/src/lib.rs
+++ b/impit-python/src/lib.rs
@@ -2,8 +2,8 @@ use pyo3::prelude::*;
 
 mod async_client;
 mod client;
-mod response;
 mod request;
+mod response;
 use async_client::AsyncClient;
 use client::Client;
 use request::RequestBody;

--- a/impit-python/src/request.rs
+++ b/impit-python/src/request.rs
@@ -15,10 +15,11 @@ pub(crate) enum RequestBody<'py> {
 pub fn form_to_bytes(data: HashMap<String, String>) -> Vec<u8> {
     let mut body = Vec::new();
     for (key, value) in data {
-        body.extend_from_slice(key.as_bytes());
-        body.extend_from_slice(b"=");
-        body.extend_from_slice(value.as_bytes());
-        body.extend_from_slice(b"&");
+        body.extend_from_slice(urlencoding::encode(key.as_str()).as_bytes());
+        body.extend_from_slice("=".as_bytes());
+        body.extend_from_slice(urlencoding::encode(value.as_str()).as_bytes());
+        body.extend_from_slice("&".as_bytes());
     }
+    body.pop(); // Remove the last "&"
     body
 }

--- a/impit-python/src/request.rs
+++ b/impit-python/src/request.rs
@@ -12,9 +12,7 @@ pub(crate) enum RequestBody<'py> {
     CatchAll(Bound<'py, PyAny>), // This extraction never fails
 }
 
-pub fn form_to_bytes(
-    data: HashMap<String, String>,
-) -> Vec<u8> {
+pub fn form_to_bytes(data: HashMap<String, String>) -> Vec<u8> {
     let mut body = Vec::new();
     for (key, value) in data {
         body.extend_from_slice(key.as_bytes());

--- a/impit-python/src/request.rs
+++ b/impit-python/src/request.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use pyo3::{Bound, FromPyObject, PyAny};
+
+#[derive(FromPyObject)]
+pub(crate) enum RequestBody<'py> {
+    #[pyo3(transparent, annotation = "bytes")]
+    Bytes(Vec<u8>),
+    #[pyo3(transparent, annotation = "dict[str, str]")]
+    Form(HashMap<String, String>),
+    #[pyo3(transparent)]
+    CatchAll(Bound<'py, PyAny>), // This extraction never fails
+}
+
+pub fn form_to_bytes(
+    data: HashMap<String, String>,
+) -> Vec<u8> {
+    let mut body = Vec::new();
+    for (key, value) in data {
+        body.extend_from_slice(key.as_bytes());
+        body.extend_from_slice(b"=");
+        body.extend_from_slice(value.as_bytes());
+        body.extend_from_slice(b"&");
+    }
+    body
+}

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -81,6 +81,19 @@ class TestRequestBody:
         assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
 
     @pytest.mark.asyncio
+    async def test_passing_string_body_in_data(self, browser: Browser) -> None:
+        impit = AsyncClient(browser=browser)
+
+        response = await impit.post(
+            get_httpbin_url('/post'),
+            data = bytearray('{"Impit-Test":"foořžš"}', 'utf-8'),
+            headers = { 'Content-Type': 'application/json' }
+        );
+
+        assert response.status_code == 200
+        assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
+
+    @pytest.mark.asyncio
     async def test_passing_binary_body(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser)
 

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -94,6 +94,18 @@ class TestRequestBody:
         assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
 
     @pytest.mark.asyncio
+    async def test_form_non_ascii_(self, browser: Browser) -> None:
+        impit = AsyncClient(browser=browser)
+
+        response = await impit.post(
+            get_httpbin_url('/post'),
+            data = { 'Impit-Test': '👾🕵🏻‍♂️🧑‍💻' },
+        );
+
+        assert response.status_code == 200
+        assert json.loads(response.text)['form']['Impit-Test'] == '👾🕵🏻‍♂️🧑‍💻'
+
+    @pytest.mark.asyncio
     async def test_passing_binary_body(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser)
 

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -94,7 +94,7 @@ class TestRequestBody:
         assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
 
     @pytest.mark.asyncio
-    async def test_form_non_ascii_(self, browser: Browser) -> None:
+    async def test_form_non_ascii(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser)
 
         response = await impit.post(

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -87,6 +87,17 @@ class TestRequestBody:
         assert response.status_code == 200
         assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
 
+    def test_form_non_ascii_(self, browser: Browser) -> None:
+        impit = Client(browser=browser)
+
+        response = impit.post(
+            get_httpbin_url('/post'),
+            data = { 'Impit-Test': '👾🕵🏻‍♂️🧑‍💻' },
+        );
+
+        assert response.status_code == 200
+        assert json.loads(response.text)['form']['Impit-Test'] == '👾🕵🏻‍♂️🧑‍💻'
+
     def test_passing_binary_body(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -87,7 +87,7 @@ class TestRequestBody:
         assert response.status_code == 200
         assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
 
-    def test_form_non_ascii_(self, browser: Browser) -> None:
+    def test_form_non_ascii(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 
         response = impit.post(

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -75,6 +75,18 @@ class TestRequestBody:
         assert response.status_code == 200
         assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
 
+    def test_passing_string_body_in_data(self, browser: Browser) -> None:
+        impit = Client(browser=browser)
+
+        response = impit.post(
+            get_httpbin_url('/post'),
+            data = bytearray('{"Impit-Test":"foořžš"}', 'utf-8'),
+            headers = { 'Content-Type': 'application/json' }
+        );
+
+        assert response.status_code == 200
+        assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
+
     def test_passing_binary_body(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 


### PR DESCRIPTION
Following the discussion under #97 , this PR widens the type accepted by the `data` parameter.

`data` now accepts both a `dict[str,str]` and a binary representation of the request body. This PR intentionally doesn't update the recently added typings in the `impit.pyi` file, as this behaviour (accepting the binary body) is considered deprecated in the `httpx` library we use as the design master.