### PR TITLE
chore(python): rerun flaky CI tests, use `uv` in CI

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -101,7 +101,7 @@ jobs:
           uv venv
           source .venv/bin/activate
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          uv pip install --group=dev -v
+          uv sync --no-build-package=impit
           uv run pytest --reruns 3
 
       - name: pytest
@@ -122,7 +122,7 @@ jobs:
             uv venv
             source .venv/bin/activate
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv pip install --group=dev -v
+            uv sync --no-build-package=impit
             uv run pytest --reruns 3
 
   musllinux:
@@ -175,12 +175,12 @@ jobs:
           options: -v ${{ github.workspace }}:/io -w /io -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }}
           run: |
             set -e
-            apk add py3-pip
-            pip install -U uv
-            uv venv
+            apk add py3-pip py3-virtualenv
+            python3 -m virtualenv .venv
             source .venv/bin/activate
+            pip install -U uv
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv pip install --group=dev -v
+            uv sync --no-build-package=impit
             uv run pytest --reruns 3
 
       - name: pytest
@@ -196,11 +196,11 @@ jobs:
             apk add py3-virtualenv
           run: |
             set -e
-            pip install -U uv
-            uv venv
+            python3 -m virtualenv .venv
             source .venv/bin/activate
+            pip install -U uv
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv pip install --group=dev -v
+            uv sync --no-build-package=impit
             uv run pytest --reruns 3
 
 #   windows:
@@ -297,6 +297,6 @@ jobs:
           uv venv
           source .venv/bin/activate
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          uv pip install --group=dev -v
+          uv sync --no-build-package=impit
           uv run pytest --reruns 3
 

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -44,43 +44,51 @@ jobs:
       - name: Set up Python
         run: uv python install
 
-      - name: Calculate openssl-vendored
-        shell: bash
-        id: is-openssl-vendored
-        run: |
-          if [[ "${{ startsWith(matrix.platform.target, 'x86') }}" == "true" ]]; then
-            echo "enabled=" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=--features openssl-vendored" >> $GITHUB_OUTPUT
-          fi
+    #   - name: Calculate openssl-vendored
+    #     shell: bash
+    #     id: is-openssl-vendored
+    #     run: |
+    #       if [[ "${{ startsWith(matrix.platform.target, 'x86') }}" == "true" ]]; then
+    #         echo "enabled=" >> $GITHUB_OUTPUT
+    #       else
+    #         echo "enabled=--features openssl-vendored" >> $GITHUB_OUTPUT
+    #       fi
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: impit-python
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          manylinux: auto
-          before-script-linux: |
-            case "${{ matrix.platform.target }}" in
-              "aarch64" | "armv7" | "s390x" | "ppc64le")
-                # NOTE: pypa/manylinux docker images are Debian based
-                sudo apt-get update
-                sudo apt-get install -y pkg-config libssl-dev perl
-                ;;
-              "x86" | "x86_64")
-                # NOTE: rust-cross/manylinux docker images are CentOS based
-                yum update -y
-                yum install -y openssl openssl-devel perl perl-IPC-Cmd
-                ;;
-            esac
+    #   - name: Build wheels
+    #     uses: PyO3/maturin-action@v1
+    #     with:
+    #       working-directory: impit-python
+    #       target: ${{ matrix.platform.target }}
+    #       args: --release --out dist --find-interpreter
+    #       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    #       manylinux: auto
+    #       before-script-linux: |
+    #         case "${{ matrix.platform.target }}" in
+    #           "aarch64" | "armv7" | "s390x" | "ppc64le")
+    #             # NOTE: pypa/manylinux docker images are Debian based
+    #             sudo apt-get update
+    #             sudo apt-get install -y pkg-config libssl-dev perl
+    #             ;;
+    #           "x86" | "x86_64")
+    #             # NOTE: rust-cross/manylinux docker images are CentOS based
+    #             yum update -y
+    #             yum install -y openssl openssl-devel perl perl-IPC-Cmd
+    #             ;;
+    #         esac
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
+    #   - name: Upload wheels
+    #     uses: actions/upload-artifact@v4
+    #     with:
+    #       name: wheels-linux-${{ matrix.platform.target }}
+    #       path: impit-python/dist
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: impit-python/dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: 14220938490
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
@@ -133,23 +141,31 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: impit-python
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          manylinux: musllinux_1_2
-          before-script-linux: |
-            sudo apt-get update
-            sudo apt-get install -y pkg-config libssl-dev perl
+    #   - name: Build wheels
+    #     uses: PyO3/maturin-action@v1
+    #     with:
+    #       working-directory: impit-python
+    #       target: ${{ matrix.platform.target }}
+    #       args: --release --out dist --find-interpreter
+    #       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    #       manylinux: musllinux_1_2
+    #       before-script-linux: |
+    #         sudo apt-get update
+    #         sudo apt-get install -y pkg-config libssl-dev perl
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
+    #   - name: Upload wheels
+    #     uses: actions/upload-artifact@v4
+    #     with:
+    #       name: wheels-musllinux-${{ matrix.platform.target }}
+    #       path: impit-python/dist
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
         with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
-          path: impit-python/dist
+            name: wheels-musllinux-${{ matrix.platform.target }}
+            path: impit-python/dist
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            run-id: 14220938490
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
@@ -187,50 +203,50 @@ jobs:
             uv pip install --group=dev -v
             uv run pytest --reruns 3
 
-  windows:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-latest
-            target: x64
-    steps:
-      - uses: actions/checkout@v4
+#   windows:
+#     runs-on: ${{ matrix.platform.runner }}
+#     strategy:
+#       matrix:
+#         platform:
+#           - runner: windows-latest
+#             target: x64
+#     steps:
+#       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+#       - name: Install uv
+#         uses: astral-sh/setup-uv@v5
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-          architecture: ${{ matrix.platform.target }}
+#       - uses: actions/setup-python@v5
+#         with:
+#           python-version: 3.x
+#           architecture: ${{ matrix.platform.target }}
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: impit-python
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+#       - name: Build wheels
+#         uses: PyO3/maturin-action@v1
+#         with:
+#           working-directory: impit-python
+#           target: ${{ matrix.platform.target }}
+#           args: --release --out dist --find-interpreter
+#           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}
-          path: impit-python/dist
+#       - name: Upload wheels
+#         uses: actions/upload-artifact@v4
+#         with:
+#           name: wheels-windows-${{ matrix.platform.target }}
+#           path: impit-python/dist
 
-      - name: pytest
-        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
-        shell: bash
-        working-directory: impit-python
-        env:
-            APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
-        run: |
-          uv venv
-          source .venv/bin/activate
-          uv pip install --no-index --find-links dist --force-reinstall impit -v
-          uv pip install --group=dev -v
-          uv run pytest --reruns 3
+#       - name: pytest
+#         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
+#         shell: bash
+#         working-directory: impit-python
+#         env:
+#             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
+#         run: |
+#           uv venv
+#           source .venv/bin/activate
+#           uv pip install --no-index --find-links dist --force-reinstall impit -v
+#           uv pip install --group=dev -v
+#           uv run pytest --reruns 3
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -250,19 +266,28 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: impit-python
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    #   - name: Build wheels
+    #     uses: PyO3/maturin-action@v1
+    #     with:
+    #       working-directory: impit-python
+    #       target: ${{ matrix.platform.target }}
+    #       args: --release --out dist --find-interpreter
+    #       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
+    #   - name: Upload wheels
+    #     uses: actions/upload-artifact@v4
+    #     with:
+    #       name: wheels-macos-${{ matrix.platform.target }}
+    #       path: impit-python/dist
+
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.platform.target }}
-          path: impit-python/dist
+            name: wheels-macos-${{ matrix.platform.target }}
+            path: impit-python/dist
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            run-id: 14220938490
 
       - name: pytest
         working-directory: impit-python

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -44,51 +44,43 @@ jobs:
       - name: Set up Python
         run: uv python install
 
-    #   - name: Calculate openssl-vendored
-    #     shell: bash
-    #     id: is-openssl-vendored
-    #     run: |
-    #       if [[ "${{ startsWith(matrix.platform.target, 'x86') }}" == "true" ]]; then
-    #         echo "enabled=" >> $GITHUB_OUTPUT
-    #       else
-    #         echo "enabled=--features openssl-vendored" >> $GITHUB_OUTPUT
-    #       fi
+      - name: Calculate openssl-vendored
+        shell: bash
+        id: is-openssl-vendored
+        run: |
+          if [[ "${{ startsWith(matrix.platform.target, 'x86') }}" == "true" ]]; then
+            echo "enabled=" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=--features openssl-vendored" >> $GITHUB_OUTPUT
+          fi
 
-    #   - name: Build wheels
-    #     uses: PyO3/maturin-action@v1
-    #     with:
-    #       working-directory: impit-python
-    #       target: ${{ matrix.platform.target }}
-    #       args: --release --out dist --find-interpreter
-    #       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    #       manylinux: auto
-    #       before-script-linux: |
-    #         case "${{ matrix.platform.target }}" in
-    #           "aarch64" | "armv7" | "s390x" | "ppc64le")
-    #             # NOTE: pypa/manylinux docker images are Debian based
-    #             sudo apt-get update
-    #             sudo apt-get install -y pkg-config libssl-dev perl
-    #             ;;
-    #           "x86" | "x86_64")
-    #             # NOTE: rust-cross/manylinux docker images are CentOS based
-    #             yum update -y
-    #             yum install -y openssl openssl-devel perl perl-IPC-Cmd
-    #             ;;
-    #         esac
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: impit-python
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: auto
+          before-script-linux: |
+            case "${{ matrix.platform.target }}" in
+              "aarch64" | "armv7" | "s390x" | "ppc64le")
+                # NOTE: pypa/manylinux docker images are Debian based
+                sudo apt-get update
+                sudo apt-get install -y pkg-config libssl-dev perl
+                ;;
+              "x86" | "x86_64")
+                # NOTE: rust-cross/manylinux docker images are CentOS based
+                yum update -y
+                yum install -y openssl openssl-devel perl perl-IPC-Cmd
+                ;;
+            esac
 
-    #   - name: Upload wheels
-    #     uses: actions/upload-artifact@v4
-    #     with:
-    #       name: wheels-linux-${{ matrix.platform.target }}
-    #       path: impit-python/dist
-
-      - name: Download wheels
-        uses: actions/download-artifact@v4
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: impit-python/dist
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: 14166233038
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
@@ -141,31 +133,23 @@ jobs:
         with:
           python-version: 3.x
 
-    #   - name: Build wheels
-    #     uses: PyO3/maturin-action@v1
-    #     with:
-    #       working-directory: impit-python
-    #       target: ${{ matrix.platform.target }}
-    #       args: --release --out dist --find-interpreter
-    #       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    #       manylinux: musllinux_1_2
-    #       before-script-linux: |
-    #         sudo apt-get update
-    #         sudo apt-get install -y pkg-config libssl-dev perl
-
-    #   - name: Upload wheels
-    #     uses: actions/upload-artifact@v4
-    #     with:
-    #       name: wheels-musllinux-${{ matrix.platform.target }}
-    #       path: impit-python/dist
-
-      - name: Download wheels
-        uses: actions/download-artifact@v4
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
         with:
-            name: wheels-musllinux-${{ matrix.platform.target }}
-            path: impit-python/dist
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            run-id: 14166233038
+          working-directory: impit-python
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: musllinux_1_2
+          before-script-linux: |
+            sudo apt-get update
+            sudo apt-get install -y pkg-config libssl-dev perl
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-musllinux-${{ matrix.platform.target }}
+          path: impit-python/dist
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
@@ -222,26 +206,19 @@ jobs:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
 
-    #   - name: Build wheels
-    #     uses: PyO3/maturin-action@v1
-    #     with:
-    #       working-directory: impit-python
-    #       target: ${{ matrix.platform.target }}
-    #       args: --release --out dist --find-interpreter
-    #       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-
-    #   - name: Upload wheels
-    #     uses: actions/upload-artifact@v4
-    #     with:
-    #       name: wheels-windows-${{ matrix.platform.target }}
-    #       path: impit-python/dist
-      - name: Download wheels
-        uses: actions/download-artifact@v4
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
         with:
-            name: wheels-windows-${{ matrix.platform.target }}
-            path: impit-python/dist
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            run-id: 14166233038
+          working-directory: impit-python
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}
+          path: impit-python/dist
 
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
@@ -274,28 +251,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
 
-    #   - name: Build wheels
-    #     uses: PyO3/maturin-action@v1
-    #     with:
-    #       working-directory: impit-python
-    #       target: ${{ matrix.platform.target }}
-    #       args: --release --out dist --find-interpreter
-    #       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-
-    #   - name: Upload wheels
-    #     uses: actions/upload-artifact@v4
-    #     with:
-    #       name: wheels-macos-${{ matrix.platform.target }}
-    #       path: impit-python/dist
-
-
-      - name: Download wheels
-        uses: actions/download-artifact@v4
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
         with:
-            name: wheels-macos-${{ matrix.platform.target }}
-            path: impit-python/dist
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            run-id: 14166233038
+          working-directory: impit-python
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: impit-python/dist
 
       - name: pytest
         working-directory: impit-python

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -172,14 +172,14 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: alpine:latest
-          options: -v ${{ github.workspace }}:/io -w /io -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }}
+          options: -v ${{ github.workspace }}:/io -w /io/impit-python -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }}
           run: |
             set -e
             apk add py3-pip py3-virtualenv
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install -U uv
-            uv pip install --no-index --find-links impit-python/dist --force-reinstall impit -v
+            uv pip install --no-index --find-links dist --force-reinstall impit -v
             uv sync --no-binary-package=impit
             uv run pytest --reruns 3
 
@@ -190,6 +190,7 @@ jobs:
           arch: ${{ matrix.platform.target }}
           distro: alpine_latest
           githubToken: ${{ github.token }}
+          dockerRunArgs: -v ${{ github.workspace }}:/io -w /io/impit-python
           env: |
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
           install: |
@@ -199,7 +200,7 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install -U uv
-            uv pip install --no-index --find-links impit-python/dist --force-reinstall impit -v
+            uv pip install --no-index --find-links dist --force-reinstall impit -v
             uv sync --no-binary-package=impit
             uv run pytest --reruns 3
 

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -100,7 +100,7 @@ jobs:
           set -e
           uv venv
           source .venv/bin/activate
-          uv sync --no-build -v || true
+          uv sync --no-install-package impit -v
           uv pip install --no-index --find-links dist --force-reinstall impit -v
           python -m pytest --reruns 3
 
@@ -121,7 +121,7 @@ jobs:
             set -e
             uv venv
             source .venv/bin/activate
-            uv sync --no-build -v || true
+            uv sync --no-install-package impit -v
             uv pip install --no-index --find-links dist --force-reinstall impit -v
             python -m pytest --reruns 3
 
@@ -179,7 +179,7 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install -U uv
-            uv sync --no-build -v || true
+            uv sync --no-install-package impit -v
             uv pip install --no-index --find-links dist --force-reinstall impit -v
             python -m pytest --reruns 3
 
@@ -200,7 +200,7 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install -U uv
-            uv sync --no-build -v || true
+            uv sync --no-install-package impit -v
             uv pip install --no-index --find-links dist --force-reinstall impit -v
             python -m pytest --reruns 3
 
@@ -297,7 +297,7 @@ jobs:
         run: |
           uv venv
           source .venv/bin/activate
-          uv sync --no-build -v || true
+          uv sync --no-install-package impit -v
           uv pip install --no-index --find-links dist --force-reinstall impit -v
           python -m pytest --reruns 3
 

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -90,6 +90,8 @@ jobs:
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
         run: |
           set -e
+          uv venv
+          source .venv/bin/activate
           uv pip install --no-index --find-links dist --force-reinstall impit
           uv pip install --group=dev
           uv run pytest --reruns 3
@@ -109,6 +111,8 @@ jobs:
             pip3 install -U uv
           run: |
             set -e
+            uv venv
+            source .venv/bin/activate
             uv pip install --no-index --find-links dist --force-reinstall impit
             uv pip install --group=dev
             uv run pytest --reruns 3
@@ -157,6 +161,8 @@ jobs:
             set -e
             apk add py3-pip
             pip install -U uv
+            uv venv
+            source .venv/bin/activate
             uv pip install --no-index --find-links dist --force-reinstall impit
             uv pip install --group=dev
             uv run pytest --reruns 3
@@ -175,6 +181,8 @@ jobs:
           run: |
             set -e
             pip install -U uv
+            uv venv
+            source .venv/bin/activate
             uv pip install --no-index --find-links dist --force-reinstall impit
             uv pip install --group=dev
             uv run pytest --reruns 3
@@ -218,6 +226,8 @@ jobs:
         env:
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
         run: |
+          uv venv
+          source .venv/bin/activate
           uv pip install --no-index --find-links dist --force-reinstall impit
           uv pip install --group=dev
           uv run pytest --reruns 3
@@ -259,6 +269,8 @@ jobs:
         env:
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
         run: |
+          uv venv
+          source .venv/bin/activate
           uv pip install --no-index --find-links dist --force-reinstall impit
           uv pip install --group=dev
           uv run pytest --reruns 3

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -102,7 +102,7 @@ jobs:
           source .venv/bin/activate
           uv sync --no-install-package impit -v
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          python -m pytest --reruns 3
+          python -m pytest
 
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
@@ -123,7 +123,7 @@ jobs:
             source .venv/bin/activate
             uv sync --no-install-package impit -v
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            python -m pytest --reruns 3
+            python -m pytest
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -181,7 +181,7 @@ jobs:
             pip install -U uv
             uv sync --no-install-package impit -v
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            python -m pytest --reruns 3
+            python -m pytest
 
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
@@ -202,7 +202,7 @@ jobs:
             pip install -U uv
             uv sync --no-install-package impit -v
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            python -m pytest --reruns 3
+            python -m pytest
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -254,7 +254,7 @@ jobs:
           source .venv/Scripts/activate
           uv sync --no-install-package impit -v
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          python -m pytest --reruns 3
+          python -m pytest
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -306,5 +306,5 @@ jobs:
           source .venv/bin/activate
           uv sync --no-install-package impit -v
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          python -m pytest --reruns 3
+          python -m pytest
 

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -101,7 +101,7 @@ jobs:
           uv venv
           source .venv/bin/activate
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          uv sync --no-build-package=impit
+          uv sync --no-binary-package=impit
           uv run pytest --reruns 3
 
       - name: pytest
@@ -122,7 +122,7 @@ jobs:
             uv venv
             source .venv/bin/activate
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv sync --no-build-package=impit
+            uv sync --no-binary-package=impit
             uv run pytest --reruns 3
 
   musllinux:
@@ -179,8 +179,8 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install -U uv
-            uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv sync --no-build-package=impit
+            uv pip install --no-index --find-links impit-python/dist --force-reinstall impit -v
+            uv sync --no-binary-package=impit
             uv run pytest --reruns 3
 
       - name: pytest
@@ -199,8 +199,8 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install -U uv
-            uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv sync --no-build-package=impit
+            uv pip install --no-index --find-links impit-python/dist --force-reinstall impit -v
+            uv sync --no-binary-package=impit
             uv run pytest --reruns 3
 
 #   windows:
@@ -297,6 +297,6 @@ jobs:
           uv venv
           source .venv/bin/activate
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          uv sync --no-build-package=impit
+          uv sync --no-binary-package=impit
           uv run pytest --reruns 3
 

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -92,8 +92,8 @@ jobs:
           set -e
           uv venv
           source .venv/bin/activate
-          uv pip install --no-index --find-links dist --force-reinstall impit
-          uv pip install --group=dev
+          uv pip install --no-index --find-links dist --force-reinstall impit -v
+          uv pip install --group=dev -v
           uv run pytest --reruns 3
 
       - name: pytest
@@ -113,8 +113,8 @@ jobs:
             set -e
             uv venv
             source .venv/bin/activate
-            uv pip install --no-index --find-links dist --force-reinstall impit
-            uv pip install --group=dev
+            uv pip install --no-index --find-links dist --force-reinstall impit -v
+            uv pip install --group=dev -v
             uv run pytest --reruns 3
 
   musllinux:
@@ -163,8 +163,8 @@ jobs:
             pip install -U uv
             uv venv
             source .venv/bin/activate
-            uv pip install --no-index --find-links dist --force-reinstall impit
-            uv pip install --group=dev
+            uv pip install --no-index --find-links dist --force-reinstall impit -v
+            uv pip install --group=dev -v
             uv run pytest --reruns 3
 
       - name: pytest
@@ -183,8 +183,8 @@ jobs:
             pip install -U uv
             uv venv
             source .venv/bin/activate
-            uv pip install --no-index --find-links dist --force-reinstall impit
-            uv pip install --group=dev
+            uv pip install --no-index --find-links dist --force-reinstall impit -v
+            uv pip install --group=dev -v
             uv run pytest --reruns 3
 
   windows:
@@ -228,8 +228,8 @@ jobs:
         run: |
           uv venv
           source .venv/bin/activate
-          uv pip install --no-index --find-links dist --force-reinstall impit
-          uv pip install --group=dev
+          uv pip install --no-index --find-links dist --force-reinstall impit -v
+          uv pip install --group=dev -v
           uv run pytest --reruns 3
 
   macos:
@@ -271,7 +271,7 @@ jobs:
         run: |
           uv venv
           source .venv/bin/activate
-          uv pip install --no-index --find-links dist --force-reinstall impit
-          uv pip install --group=dev
+          uv pip install --no-index --find-links dist --force-reinstall impit -v
+          uv pip install --group=dev -v
           uv run pytest --reruns 3
 

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -88,7 +88,7 @@ jobs:
           name: wheels-linux-${{ matrix.platform.target }}
           path: impit-python/dist
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: 14220938490
+          run-id: 14166233038
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
@@ -100,9 +100,9 @@ jobs:
           set -e
           uv venv
           source .venv/bin/activate
+          uv sync --no-build -v || true
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          uv sync --no-binary-package=impit
-          uv run pytest --reruns 3
+          python -m pytest --reruns 3
 
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
@@ -121,9 +121,9 @@ jobs:
             set -e
             uv venv
             source .venv/bin/activate
+            uv sync --no-build -v || true
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv sync --no-binary-package=impit
-            uv run pytest --reruns 3
+            python -m pytest --reruns 3
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -165,7 +165,7 @@ jobs:
             name: wheels-musllinux-${{ matrix.platform.target }}
             path: impit-python/dist
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            run-id: 14220938490
+            run-id: 14166233038
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
@@ -179,9 +179,9 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install -U uv
+            uv sync --no-build -v || true
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv sync --no-binary-package=impit
-            uv run pytest --reruns 3
+            python -m pytest --reruns 3
 
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
@@ -200,9 +200,9 @@ jobs:
             python3 -m virtualenv .venv
             source .venv/bin/activate
             pip install -U uv
+            uv sync --no-build -v || true
             uv pip install --no-index --find-links dist --force-reinstall impit -v
-            uv sync --no-binary-package=impit
-            uv run pytest --reruns 3
+            python -m pytest --reruns 3
 
 #   windows:
 #     runs-on: ${{ matrix.platform.runner }}
@@ -247,7 +247,7 @@ jobs:
 #           source .venv/bin/activate
 #           uv pip install --no-index --find-links dist --force-reinstall impit -v
 #           uv pip install --group=dev -v
-#           uv run pytest --reruns 3
+#           python -m pytest --reruns 3
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -288,7 +288,7 @@ jobs:
             name: wheels-macos-${{ matrix.platform.target }}
             path: impit-python/dist
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            run-id: 14220938490
+            run-id: 14166233038
 
       - name: pytest
         working-directory: impit-python
@@ -297,7 +297,7 @@ jobs:
         run: |
           uv venv
           source .venv/bin/activate
+          uv sync --no-build -v || true
           uv pip install --no-index --find-links dist --force-reinstall impit -v
-          uv sync --no-binary-package=impit
-          uv run pytest --reruns 3
+          python -m pytest --reruns 3
 

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -37,9 +37,12 @@ jobs:
         #     target: aarch64
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install
 
       - name: Calculate openssl-vendored
         shell: bash
@@ -78,6 +81,7 @@ jobs:
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: impit-python/dist
+
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
         shell: bash
@@ -86,11 +90,10 @@ jobs:
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
         run: |
           set -e
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install impit --no-index --find-links dist --force-reinstall
-          pip install pytest pytest-asyncio
-          python -m pytest
+          uv pip install --no-index --find-links dist --force-reinstall impit
+          uv pip install --group=dev
+          uv run pytest --reruns 3
+
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
         uses: uraimo/run-on-arch-action@v2
@@ -103,11 +106,12 @@ jobs:
           install: |
             apt-get update
             apt-get install -y --no-install-recommends python3 python3-pip
-            pip3 install -U pip pytest pytest-asyncio
+            pip3 install -U uv
           run: |
             set -e
-            pip3 install impit --no-index --find-links impit-python/dist --force-reinstall
-            pytest
+            uv pip install --no-index --find-links dist --force-reinstall impit
+            uv pip install --group=dev
+            uv run pytest --reruns 3
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -120,9 +124,11 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -134,11 +140,13 @@ jobs:
           before-script-linux: |
             sudo apt-get update
             sudo apt-get install -y pkg-config libssl-dev perl
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: impit-python/dist
+
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
         uses: addnab/docker-run-action@v3
@@ -147,12 +155,12 @@ jobs:
           options: -v ${{ github.workspace }}:/io -w /io -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }}
           run: |
             set -e
-            apk add py3-pip py3-virtualenv
-            python3 -m virtualenv .venv
-            source .venv/bin/activate
-            pip install impit --no-index --find-links impit-python/dist/ --force-reinstall
-            pip install pytest pytest-asyncio
-            pytest
+            apk add py3-pip
+            pip install -U uv
+            uv pip install --no-index --find-links dist --force-reinstall impit
+            uv pip install --group=dev
+            uv run pytest --reruns 3
+
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
         uses: uraimo/run-on-arch-action@v2
@@ -166,11 +174,10 @@ jobs:
             apk add py3-virtualenv
           run: |
             set -e
-            python3 -m virtualenv .venv
-            source .venv/bin/activate
-            pip install pytest pytest-asyncio
-            pip install impit --no-index --find-links impit-python/dist/ --force-reinstall
-            pytest
+            pip install -U uv
+            uv pip install --no-index --find-links dist --force-reinstall impit
+            uv pip install --group=dev
+            uv run pytest --reruns 3
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -181,10 +188,15 @@ jobs:
             target: x64
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -192,11 +204,13 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: impit-python/dist
+
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
@@ -204,12 +218,9 @@ jobs:
         env:
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
         run: |
-          set -e
-          python3 -m venv .venv
-          source .venv/Scripts/activate
-          pip install impit --no-index --find-links dist --force-reinstall
-          pip install pytest pytest-asyncio
-          python -m pytest
+          uv pip install --no-index --find-links dist --force-reinstall impit
+          uv pip install --group=dev
+          uv run pytest --reruns 3
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -222,9 +233,13 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -232,20 +247,19 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: impit-python/dist
+
       - name: pytest
         working-directory: impit-python
         env:
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
         run: |
-          set -e
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install impit --no-index --find-links dist --force-reinstall
-          pip install pytest pytest-asyncio
-          python -m pytest
+          uv pip install --no-index --find-links dist --force-reinstall impit
+          uv pip install --group=dev
+          uv run pytest --reruns 3
 

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -204,50 +204,57 @@ jobs:
             uv pip install --no-index --find-links dist --force-reinstall impit -v
             python -m pytest --reruns 3
 
-#   windows:
-#     runs-on: ${{ matrix.platform.runner }}
-#     strategy:
-#       matrix:
-#         platform:
-#           - runner: windows-latest
-#             target: x64
-#     steps:
-#       - uses: actions/checkout@v4
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+    steps:
+      - uses: actions/checkout@v4
 
-#       - name: Install uv
-#         uses: astral-sh/setup-uv@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
-#       - uses: actions/setup-python@v5
-#         with:
-#           python-version: 3.x
-#           architecture: ${{ matrix.platform.target }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          architecture: ${{ matrix.platform.target }}
 
-#       - name: Build wheels
-#         uses: PyO3/maturin-action@v1
-#         with:
-#           working-directory: impit-python
-#           target: ${{ matrix.platform.target }}
-#           args: --release --out dist --find-interpreter
-#           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    #   - name: Build wheels
+    #     uses: PyO3/maturin-action@v1
+    #     with:
+    #       working-directory: impit-python
+    #       target: ${{ matrix.platform.target }}
+    #       args: --release --out dist --find-interpreter
+    #       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
-#       - name: Upload wheels
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: wheels-windows-${{ matrix.platform.target }}
-#           path: impit-python/dist
+    #   - name: Upload wheels
+    #     uses: actions/upload-artifact@v4
+    #     with:
+    #       name: wheels-windows-${{ matrix.platform.target }}
+    #       path: impit-python/dist
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+            name: wheels-windows-${{ matrix.platform.target }}
+            path: impit-python/dist
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            run-id: 14166233038
 
-#       - name: pytest
-#         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
-#         shell: bash
-#         working-directory: impit-python
-#         env:
-#             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
-#         run: |
-#           uv venv
-#           source .venv/bin/activate
-#           uv pip install --no-index --find-links dist --force-reinstall impit -v
-#           uv pip install --group=dev -v
-#           python -m pytest --reruns 3
+      - name: pytest
+        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
+        shell: bash
+        working-directory: impit-python
+        env:
+            APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
+        run: |
+          uv venv
+          source .venv/Scripts/activate
+          uv sync --no-install-package impit -v
+          uv pip install --no-index --find-links dist --force-reinstall impit -v
+          python -m pytest --reruns 3
 
   macos:
     runs-on: ${{ matrix.platform.runner }}

--- a/impit-python/pyproject.toml
+++ b/impit-python/pyproject.toml
@@ -107,7 +107,7 @@ known-first-party = ["impit"]
 addopts = "-ra"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
-reruns = 3
+reruns = "3"
 
 [tool.mypy]
 python_version = "3.9"

--- a/impit-python/pyproject.toml
+++ b/impit-python/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = []
 dev = [
     "mypy",
     "pytest-asyncio",
+    "pytest-rerunfailures",
     "pytest-cov",
     "pytest-only",
     "pytest-xdist",

--- a/impit-python/pyproject.toml
+++ b/impit-python/pyproject.toml
@@ -107,7 +107,7 @@ known-first-party = ["impit"]
 addopts = "-ra"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
-timeout = 1200
+reruns = 3
 
 [tool.mypy]
 python_version = "3.9"

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -26,6 +26,9 @@ class TestBasicRequests:
         resp = impit.get(f'{protocol}example.org')
         assert resp.status_code == 200
 
+    def test_retries(self, protocol: str, browser: Browser) -> None:
+        assert False == True
+
     def test_headers_work(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -26,9 +26,6 @@ class TestBasicRequests:
         resp = impit.get(f'{protocol}example.org')
         assert resp.status_code == 200
 
-    def test_retries(self, protocol: str, browser: Browser) -> None:
-        assert False == True
-
     def test_headers_work(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 

--- a/impit-python/uv.lock
+++ b/impit-python/uv.lock
@@ -116,6 +116,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-only" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -130,6 +131,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-only" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -268,6 +270,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/2f/937d554943477a540aa2aae2b4c47ad41c2f089f47691288938c67e94143/pytest_only-2.1.2.tar.gz", hash = "sha256:e341acc083e3bb66debc660b7d5d71ae3b31da5edc2a737280d7304221ab0c29", size = 4863 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/95/3cf1a035048ee224a5dc701a3f41a5ec8684b030d217517bdf7da2f545aa/pytest_only-2.1.2-py3-none-any.whl", hash = "sha256:04dffe2aed64a741145ce5ad25b5df3ae4212e01ff885a8821fd2318eb509e91", size = 6456 },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/47/ec4e12f45f4b9fac027a41ccaabb353ed4f23695aae860258ba11a84ed9b/pytest-rerunfailures-15.0.tar.gz", hash = "sha256:2d9ac7baf59f4c13ac730b47f6fa80e755d1ba0581da45ce30b72fb3542b4474", size = 21816 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/37/54e5ffc7c0cebee7cf30a3ac5915faa7e7abf8bdfdf3228c277f7c192489/pytest_rerunfailures-15.0-py3-none-any.whl", hash = "sha256:dd150c4795c229ef44320adc9a0c0532c51b78bb7a6843a8c53556b9a611df1a", size = 13017 },
 ]
 
 [[package]]


### PR DESCRIPTION
Uses state-of-the-art package manager for Python and installs the test dependencies in CI from the `pyproject.toml` file, to ensure all the required Python deps are present in test-time.