### PR TITLE
fix(py): `response.encoding` contains the actual encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "hickory-client",
  "hickory-proto",
  "log",
+ "mime",
  "num-bigint",
  "reqwest",
  "rustls",

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -25,6 +25,13 @@ class TestBasicRequests:
 
         resp = impit.get(f'{protocol}example.org')
         assert resp.status_code == 200
+    
+    def test_content_encoding(self, browser: Browser) -> None:
+        impit = Client(browser=browser)
+
+        resp = impit.get(get_httpbin_url('/encoding/utf8'))
+        assert resp.status_code == 200
+        assert resp.encoding == 'utf-8'
 
     def test_headers_work(self, browser: Browser) -> None:
         impit = Client(browser=browser)

--- a/impit/Cargo.toml
+++ b/impit/Cargo.toml
@@ -10,6 +10,7 @@ encoding = "0.2.33"
 hickory-client = "0.25.1"
 hickory-proto = "0.25.1"
 log = "0.4.22"
+mime = "0.3.17"
 num-bigint = "0.4.6"
 reqwest = { version = "0.12.9", features = ["json", "gzip", "brotli", "zstd", "deflate", "rustls-tls", "http3", "cookies", "stream"] }
 rustls = { version="0.23.16", features=["impit"] }

--- a/impit/src/response_parsing/mod.rs
+++ b/impit/src/response_parsing/mod.rs
@@ -129,7 +129,9 @@ impl ContentType {
         let mime: Mime = content_type.parse().unwrap_or(TEXT_PLAIN);
 
         match mime.get_param("charset") {
-            Some(encoding) => Ok(ContentType { charset: encoding.to_string() }),
+            Some(encoding) => Ok(ContentType {
+                charset: encoding.to_string(),
+            }),
             None => Err(ContentTypeError::InvalidContentType),
         }
     }

--- a/impit/src/response_parsing/mod.rs
+++ b/impit/src/response_parsing/mod.rs
@@ -1,4 +1,5 @@
 use encoding::Encoding;
+use mime::{Mime, TEXT_PLAIN};
 
 /// Implements the BOM sniffing algorithm to detect the encoding of the response.
 /// If the BOM sniffing algorithm fails, the function returns `None`.
@@ -115,7 +116,7 @@ pub fn decode(bytes: &[u8], encoding_prior_knowledge: Option<encoding::EncodingR
 /// decode(&bytes, content_type.into());
 /// ```
 pub struct ContentType {
-    charset: String,
+    pub charset: String,
 }
 
 /// Error enum for the `ContentType` struct operations.
@@ -125,15 +126,12 @@ pub enum ContentTypeError {
 
 impl ContentType {
     pub fn from(content_type: &str) -> Result<Self, ContentTypeError> {
-        let parts: Vec<&str> = content_type.split("charset=").collect();
+        let mime: Mime = content_type.parse().unwrap_or(TEXT_PLAIN);
 
-        if parts.len() != 2 || parts[1].is_empty() {
-            return Err(ContentTypeError::InvalidContentType);
+        match mime.get_param("charset") {
+            Some(encoding) => Ok(ContentType { charset: encoding.to_string() }),
+            None => Err(ContentTypeError::InvalidContentType),
         }
-
-        Ok(ContentType {
-            charset: String::from(parts[1]),
-        })
     }
 }
 


### PR DESCRIPTION
Parses the `content-type` header for the `charset` parameter.

Closes #109 

Note that the response encoding in `impit` is still not on par with `httpx`, which accepts encoding as parameter, or "autodetect" functions ([docs here](https://www.python-httpx.org/advanced/text-encodings/))