### PR TITLE
ci: Add Python CI lint & type checks

### DIFF
--- a/.github/workflows/python-code-checks.yaml
+++ b/.github/workflows/python-code-checks.yaml
@@ -1,0 +1,24 @@
+name: Run code checks
+
+on:
+    # Trigger it when a new pull request is opened.
+    pull_request:
+
+    # Trigger it  when pushing to the master branch.
+    push:
+        branches:
+            - master
+        tags-ignore:
+            - "**" # Ignore all tags to prevent duplicate checks when tags are pushed.
+
+    # Allow manual trigger.
+    workflow_dispatch:
+
+jobs:
+    lint_check:
+        name: Lint check
+        uses: apify/workflows/.github/workflows/python_lint_check.yaml@main
+
+    type_check:
+        name: Type check
+        uses: apify/workflows/.github/workflows/python_type_check.yaml@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
 /target
 /artifacts
 .idea
-.venv
+
+# Python
 __pycache__
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.venv
+venv
+.coverage
+*.so
+*.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Makefile for the impit-python repository, mostly for the CI.
+
+.PHONY: install-dev lint type-check format check-code
+
+install-dev:
+	cd impit-python uv sync --all-extras
+
+lint:
+	cd impit-python && uv run ruff format --check
+	cd impit-python && uv run ruff check
+
+type-check:
+	cd impit-python && uv run mypy
+
+format:
+	cd impit-python && uv run ruff check --fix
+	cd impit-python && uv run ruff format
+
+check-code: lint type-check unit-tests

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -86,7 +86,7 @@ class TestRequestBody:
 
         response = await impit.post(
             get_httpbin_url('/post'),
-            data=bytearray('{"Impit-Test":"foořžš"}', 'utf-8'),
+            content=bytearray('{"Impit-Test":"foořžš"}', 'utf-8'),
             headers={'Content-Type': 'application/json'},
         )
         assert response.status_code == 200

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -80,7 +80,7 @@ class TestRequestBody:
 
         response = impit.post(
             get_httpbin_url('/post'),
-            data=bytearray('{"Impit-Test":"foořžš"}', 'utf-8'),
+            content=bytearray('{"Impit-Test":"foořžš"}', 'utf-8'),
             headers={'Content-Type': 'application/json'},
         )
         assert response.status_code == 200


### PR DESCRIPTION
- The CI pipelines are shared from `apify/workflows` and require execution via `make` from the root directory.
- I fixed the two types in the tests for the type checker.