### PR TITLE
feat(py): add `url` and `content` property for `Response`, smart `.text` decoding, options for redirects 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,6 +1551,7 @@ name = "impit-python"
 version = "0.0.0"
 dependencies = [
  "bytes",
+ "encoding",
  "h2",
  "impit",
  "napi-build",

--- a/impit-python/Cargo.toml
+++ b/impit-python/Cargo.toml
@@ -19,6 +19,7 @@ pyo3 = { version = "0.24", features = ["extension-module"] }
 pyo3-async-runtimes = { version = "0.24", features = ["attributes", "async-std-runtime", "tokio-runtime"] }
 openssl = { version = "*", features = ["vendored"] }
 urlencoding = "2.1.3"
+encoding = "0.2.33"
 
 [build-dependencies]
 napi-build = "2.1.4"

--- a/impit-python/python/impit/impit.pyi
+++ b/impit-python/python/impit/impit.pyi
@@ -48,6 +48,8 @@ class Client:
         timeout: float | None = None,
         verify: bool | None = None,
         default_encoding: str | None = None,
+        follow_redirects: bool | None = None,
+        max_redirects: int | None = None,
     ) -> None:
         """Initialize a synchronous HTTP client.
 
@@ -59,6 +61,8 @@ class Client:
             verify: Verify SSL certificates (set to False to ignore TLS errors)
             default_encoding: Default encoding for response.text field (e.g., "utf-8", "cp1252"). Overrides `content-type`
                 header and bytestream prescan.
+            follow_redirects: Whether to follow redirects (default: False)
+            max_redirects: Maximum number of redirects to follow (default: 20)
         """
 
     def get(
@@ -256,6 +260,8 @@ class AsyncClient:
         timeout: float | None = None,
         verify: bool | None = None,
         default_encoding: str | None = None,
+        follow_redirects: bool | None = None,
+        max_redirects: int | None = None,
     ) -> None:
         """Initialize an asynchronous HTTP client.
 
@@ -267,6 +273,8 @@ class AsyncClient:
             verify: Verify SSL certificates (set to False to ignore TLS errors)
             default_encoding: Default encoding for response.text field (e.g., "utf-8", "cp1252"). Overrides `content-type`
                 header and bytestream prescan.
+            follow_redirects: Whether to follow redirects (default: False)
+            max_redirects: Maximum number of redirects to follow (default: 20)
         """
 
     async def get(

--- a/impit-python/python/impit/impit.pyi
+++ b/impit-python/python/impit/impit.pyi
@@ -30,6 +30,12 @@ class Response:
     is_redirect: bool
     """Whether the response is a redirect"""
 
+    url: str
+    """Final URL"""
+
+    content: bytes
+    """Response body as bytes"""
+
 
 class Client:
     """Synchronous HTTP client with browser impersonation capabilities."""

--- a/impit-python/python/impit/impit.pyi
+++ b/impit-python/python/impit/impit.pyi
@@ -22,7 +22,7 @@ class Response:
     """Response headers as a dictionary"""
 
     text: str
-    """Response body as text"""
+    """Response body as text. Decoded from `content` using `encoding`."""
 
     encoding: str
     """Response content encoding"""
@@ -47,6 +47,7 @@ class Client:
         proxy: str | None = None,
         timeout: float | None = None,
         verify: bool | None = None,
+        default_encoding: str | None = None,
     ) -> None:
         """Initialize a synchronous HTTP client.
 
@@ -56,6 +57,8 @@ class Client:
             proxy: Proxy URL to use
             timeout: Default request timeout in seconds
             verify: Verify SSL certificates (set to False to ignore TLS errors)
+            default_encoding: Default encoding for response.text field (e.g., "utf-8", "cp1252"). Overrides `content-type`
+                header and bytestream prescan.
         """
 
     def get(
@@ -252,6 +255,7 @@ class AsyncClient:
         proxy: str | None = None,
         timeout: float | None = None,
         verify: bool | None = None,
+        default_encoding: str | None = None,
     ) -> None:
         """Initialize an asynchronous HTTP client.
 
@@ -261,6 +265,8 @@ class AsyncClient:
             proxy: Proxy URL to use
             timeout: Default request timeout in seconds
             verify: Verify SSL certificates (set to False to ignore TLS errors)
+            default_encoding: Default encoding for response.text field (e.g., "utf-8", "cp1252"). Overrides `content-type`
+                header and bytestream prescan.
         """
 
     async def get(

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -22,7 +22,7 @@ pub(crate) struct AsyncClient {
 #[pymethods]
 impl AsyncClient {
     #[new]
-    #[pyo3(signature = (browser=None, http3=None, proxy=None, timeout=None, verify=None, default_encoding=None))]
+    #[pyo3(signature = (browser=None, http3=None, proxy=None, timeout=None, verify=None, default_encoding=None, follow_redirects=None, max_redirects=Some(20)))]
     pub fn new(
         browser: Option<String>,
         http3: Option<bool>,
@@ -30,6 +30,8 @@ impl AsyncClient {
         timeout: Option<f64>,
         verify: Option<bool>,
         default_encoding: Option<String>,
+        follow_redirects: Option<bool>,
+        max_redirects: Option<u16>,
     ) -> Self {
         let builder = ImpitBuilder::default();
 
@@ -60,6 +62,13 @@ impl AsyncClient {
         let builder = match verify {
             Some(false) => builder.with_ignore_tls_errors(true),
             _ => builder,
+        };
+
+        let builder = match follow_redirects {
+            Some(true) => builder.with_redirect(impit::impit::RedirectBehavior::FollowRedirect(
+                max_redirects.unwrap_or(20).into(),
+            )),
+            _ => builder.with_redirect(impit::impit::RedirectBehavior::ManualRedirect),
         };
 
         Self {

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -16,18 +16,20 @@ use crate::{request::form_to_bytes, response::ImpitPyResponse, RequestBody};
 #[pyclass]
 pub(crate) struct AsyncClient {
     impit_config: ImpitBuilder,
+    default_encoding: Option<String>,
 }
 
 #[pymethods]
 impl AsyncClient {
     #[new]
-    #[pyo3(signature = (browser=None, http3=None, proxy=None, timeout=None, verify=None))]
+    #[pyo3(signature = (browser=None, http3=None, proxy=None, timeout=None, verify=None, default_encoding=None))]
     pub fn new(
         browser: Option<String>,
         http3: Option<bool>,
         proxy: Option<String>,
         timeout: Option<f64>,
         verify: Option<bool>,
+        default_encoding: Option<String>,
     ) -> Self {
         let builder = ImpitBuilder::default();
 
@@ -62,6 +64,7 @@ impl AsyncClient {
 
         Self {
             impit_config: builder,
+            default_encoding,
         }
     }
 
@@ -296,11 +299,13 @@ impl AsyncClient {
             tx.send(response).unwrap();
         });
 
+        let default_encoding = self.default_encoding.clone();
+
         pyo3_async_runtimes::async_std::future_into_py::<_, ImpitPyResponse>(py, async {
             let response = rx.await.unwrap();
 
             response
-                .map(|response| response.into())
+                .map(|response| ImpitPyResponse::from(response, default_encoding))
                 .map_err(|err| match err {
                     ErrorType::RequestError(r) => {
                         PyErr::new::<PyRuntimeError, _>(format!("{:#?}", r))

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -231,12 +231,7 @@ impl Client {
                     _ => Err(ErrorType::InvalidMethod(method.to_string())),
                 }
             })
-            .map(|response| {
-                ImpitPyResponse::from(
-                    response,
-                    self.default_encoding.clone(),
-                )
-            })
+            .map(|response| ImpitPyResponse::from(response, self.default_encoding.clone()))
             .map_err(|err| match err {
                 ErrorType::RequestError(r) => PyErr::new::<PyRuntimeError, _>(format!("{:#?}", r)),
                 e => PyErr::new::<PyValueError, _>(e.to_string()),

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -18,18 +18,20 @@ use crate::{
 #[pyclass]
 pub(crate) struct Client {
     impit: Impit,
+    default_encoding: Option<String>,
 }
 
 #[pymethods]
 impl Client {
     #[new]
-    #[pyo3(signature = (browser=None, http3=None, proxy=None, timeout=None, verify=None))]
+    #[pyo3(signature = (browser=None, http3=None, proxy=None, timeout=None, verify=None, default_encoding=None))]
     pub fn new(
         browser: Option<String>,
         http3: Option<bool>,
         proxy: Option<String>,
         timeout: Option<f64>,
         verify: Option<bool>,
+        default_encoding: Option<String>,
     ) -> Self {
         let builder = ImpitBuilder::default();
 
@@ -65,6 +67,7 @@ impl Client {
         pyo3_async_runtimes::tokio::get_runtime().block_on(async {
             Self {
                 impit: builder.build(),
+                default_encoding,
             }
         })
     }
@@ -228,7 +231,12 @@ impl Client {
                     _ => Err(ErrorType::InvalidMethod(method.to_string())),
                 }
             })
-            .map(|response| response.into())
+            .map(|response| {
+                ImpitPyResponse::from(
+                    response,
+                    self.default_encoding.clone(),
+                )
+            })
             .map_err(|err| match err {
                 ErrorType::RequestError(r) => PyErr::new::<PyRuntimeError, _>(format!("{:#?}", r)),
                 e => PyErr::new::<PyValueError, _>(e.to_string()),

--- a/impit-python/src/lib.rs
+++ b/impit-python/src/lib.rs
@@ -29,7 +29,7 @@ fn impit(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
                     timeout: Option<f64>,
                     force_http3: Option<bool>,
                 ) -> Result<response::ImpitPyResponse, PyErr> {
-                    let mut client = Client::new(None, None, None, None, None, None);
+                    let mut client = Client::new(None, None, None, None, None, None, None, None);
 
                     client.$name(url, content, data, headers, timeout, force_http3)
                 }

--- a/impit-python/src/lib.rs
+++ b/impit-python/src/lib.rs
@@ -29,7 +29,7 @@ fn impit(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
                     timeout: Option<f64>,
                     force_http3: Option<bool>,
                 ) -> Result<response::ImpitPyResponse, PyErr> {
-                    let mut client = Client::new(None, None, None, None, None);
+                    let mut client = Client::new(None, None, None, None, None, None);
 
                     client.$name(url, content, data, headers, timeout, force_http3)
                 }

--- a/impit-python/src/response.rs
+++ b/impit-python/src/response.rs
@@ -81,10 +81,8 @@ impl ImpitPyResponse {
             .and_then(|ct| ContentType::from(ct).ok())
             .and_then(|ct| ct.into());
 
-        let encoding = 
-            preferred_encoding.and_then(|e| {
-                encoding::label::encoding_from_whatwg_label(&e)
-            })
+        let encoding = preferred_encoding
+            .and_then(|e| encoding::label::encoding_from_whatwg_label(&e))
             .or(content_type_charset)
             .or(impit::utils::determine_encoding(content.as_slice()))
             .unwrap_or(impit::utils::encodings::UTF_8);

--- a/impit-python/src/response.rs
+++ b/impit-python/src/response.rs
@@ -20,6 +20,10 @@ pub struct ImpitPyResponse {
     encoding: String,
     #[pyo3(get)]
     is_redirect: bool,
+    #[pyo3(get)]
+    url: String,
+    #[pyo3(get)]
+    content: Vec<u8>,
     // #[pyo3(get)]
     // request: Request,
     // #[pyo3(get)]
@@ -41,32 +45,55 @@ impl ImpitPyResponse {
 
 impl From<Response> for ImpitPyResponse {
     fn from(val: Response) -> Self {
+        let status_code = val.status().as_u16();
+        let url = val.url().to_string();
+        let reason_phrase = val
+            .status()
+            .canonical_reason()
+            .unwrap_or_default()
+            .to_string();
+        let http_version = match val.version() {
+            Version::HTTP_09 => "HTTP/0.9".to_string(),
+            Version::HTTP_10 => "HTTP/1.0".to_string(),
+            Version::HTTP_11 => "HTTP/1.1".to_string(),
+            Version::HTTP_2 => "HTTP/2".to_string(),
+            Version::HTTP_3 => "HTTP/3".to_string(),
+            _ => "Unknown".to_string(),
+        };
+        let is_redirect = val.status().is_redirection();
+        let headers = HashMap::from_iter(val.headers().iter().map(|(k, v)| {
+            (
+                k.as_str().to_string(),
+                v.to_str().unwrap_or_default().to_string(),
+            )
+        }));
+        let encoding = val
+            .headers()
+            .get("content-type")
+            .unwrap_or(&HeaderValue::from_static("text/plain"))
+            .to_str()
+            .unwrap_or_default()
+            .to_string();
+
+        let content = pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+            match val.bytes().await {
+                Ok(bytes) => bytes.to_vec(),
+                Err(_) => Vec::new(),
+            }
+        });
+
+        let text = String::from_utf8_lossy(&content).to_string();
+
         ImpitPyResponse {
-            status_code: val.status().as_u16(),
-            reason_phrase: val.status().canonical_reason().unwrap().to_string(),
-            http_version: match val.version() {
-                Version::HTTP_09 => "HTTP/0.9".to_string(),
-                Version::HTTP_10 => "HTTP/1.0".to_string(),
-                Version::HTTP_11 => "HTTP/1.1".to_string(),
-                Version::HTTP_2 => "HTTP/2".to_string(),
-                Version::HTTP_3 => "HTTP/3".to_string(),
-                _ => "Unknown".to_string(),
-            },
-            is_redirect: val.status().is_redirection(),
-            headers: HashMap::from_iter(
-                val.headers()
-                    .iter()
-                    .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap().to_string())),
-            ),
-            encoding: val
-                .headers()
-                .get("content-type")
-                .unwrap_or(&HeaderValue::from_static("text/plain"))
-                .to_str()
-                .unwrap()
-                .to_string(),
-            text: pyo3_async_runtimes::tokio::get_runtime()
-                .block_on(async { val.text().await.unwrap_or_default() }),
+            status_code,
+            url,
+            reason_phrase,
+            http_version,
+            is_redirect,
+            headers,
+            encoding,
+            text,
+            content,
         }
     }
 }

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -87,19 +87,15 @@ class TestBasicRequests:
         assert not response.is_redirect
 
         assert response.url == target_url
-    
+
     @pytest.mark.asyncio
     async def test_limit_redirects(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser, follow_redirects=True, max_redirects=1)
 
-        redirect_url = get_httpbin_url(f'/absolute-redirect/3')
-        
-        try:
-            response = await impit.get(redirect_url)
-        except Exception as e:
-            assert isinstance(e, RuntimeError)
-            assert 'TooManyRedirects' in str(e)
-            return
+        redirect_url = get_httpbin_url('/absolute-redirect/3')
+
+        with pytest.raises(RuntimeError, match='TooManyRedirects'):
+            await impit.get(redirect_url)
 
 
 @pytest.mark.parametrize(

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -63,7 +63,7 @@ class TestBasicRequests:
     async def test_default_no_redirect(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser)
 
-        target_url = get_httpbin_url('/')
+        target_url = 'https://example.org/'
         redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
 
         response = await impit.get(redirect_url)
@@ -78,7 +78,7 @@ class TestBasicRequests:
     async def test_follow_redirects(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser, follow_redirects=True)
 
-        target_url = get_httpbin_url('/')
+        target_url = 'https://example.org/'
         redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
 
         response = await impit.get(redirect_url)

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -1,5 +1,4 @@
 import json
-from urllib.parse import urlencode
 
 import pytest
 
@@ -64,7 +63,7 @@ class TestBasicRequests:
         impit = AsyncClient(browser=browser)
 
         target_url = 'https://example.org/'
-        redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
+        redirect_url = get_httpbin_url('/redirect-to', query={'url': target_url})
 
         response = await impit.get(redirect_url)
 
@@ -79,7 +78,7 @@ class TestBasicRequests:
         impit = AsyncClient(browser=browser, follow_redirects=True)
 
         target_url = 'https://example.org/'
-        redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
+        redirect_url = get_httpbin_url('/redirect-to', query={'url': target_url})
 
         response = await impit.get(redirect_url)
 

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -64,7 +64,7 @@ class TestBasicRequests:
         impit = AsyncClient(browser=browser)
 
         target_url = get_httpbin_url('/')
-        redirect_url = get_httpbin_url(f'/redirect-to?{urlencode({"url": target_url})}')
+        redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
 
         response = await impit.get(redirect_url)
 
@@ -79,7 +79,7 @@ class TestBasicRequests:
         impit = AsyncClient(browser=browser, follow_redirects=True)
 
         target_url = get_httpbin_url('/')
-        redirect_url = get_httpbin_url(f'/redirect-to?{urlencode({"url": target_url})}')
+        redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
 
         response = await impit.get(redirect_url)
 

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -1,5 +1,4 @@
 import json
-from urllib.parse import urlencode
 
 import pytest
 
@@ -66,7 +65,7 @@ class TestBasicRequests:
         impit = Client(browser=browser)
 
         target_url = 'https://example.org/'
-        redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
+        redirect_url = get_httpbin_url('/redirect-to', query={'url': target_url})
 
         response = impit.get(redirect_url)
 
@@ -80,7 +79,7 @@ class TestBasicRequests:
         impit = Client(browser=browser, follow_redirects=True)
 
         target_url = 'https://example.org/'
-        redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
+        redirect_url = get_httpbin_url('/redirect-to', query={'url': target_url})
 
         response = impit.get(redirect_url)
 

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -65,7 +65,7 @@ class TestBasicRequests:
     def test_default_no_redirect(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 
-        target_url = get_httpbin_url('/')
+        target_url = 'https://example.org/'
         redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
 
         response = impit.get(redirect_url)
@@ -79,7 +79,7 @@ class TestBasicRequests:
     def test_follow_redirects(self, browser: Browser) -> None:
         impit = Client(browser=browser, follow_redirects=True)
 
-        target_url = get_httpbin_url('/')
+        target_url = 'https://example.org/'
         redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
 
         response = impit.get(redirect_url)

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import urlencode
 
 import pytest
 
@@ -53,6 +54,21 @@ class TestBasicRequests:
         m = getattr(impit, method.lower())
 
         m('https://example.org')
+
+    async def test_url_with_redirect(self, browser: Browser) -> None:
+        impit = Client(browser=browser)
+
+        target_url = get_httpbin_url('/')
+        redirect_url = get_httpbin_url(f'/redirect-to?{urlencode({"url": target_url})}')
+
+        response = impit.get(redirect_url)
+
+        assert response.status_code == 200
+        assert response.url == target_url
+        assert response.url != redirect_url
+
+        # The target page does not have a redirect status
+        assert not response.is_redirect
 
 
 @pytest.mark.parametrize(
@@ -140,3 +156,13 @@ class TestRequestBody:
         response = m(get_httpbin_url(f'/{method.lower()}'), content=b'foo')
         assert response.status_code == 200
         assert json.loads(response.text)['data'] == 'foo'
+
+    async def test_content(self, browser: Browser) -> None:
+        impit = Client(browser=browser)
+
+        response = impit.get(get_httpbin_url('/'))
+
+        assert response.status_code == 200
+        assert isinstance(response.content, bytes)
+        assert isinstance(response.text, str)
+        assert response.content.decode('utf-8') == response.text

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -26,7 +26,7 @@ class TestBasicRequests:
 
         resp = impit.get(f'{protocol}example.org')
         assert resp.status_code == 200
-    
+
     def test_content_encoding(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 
@@ -88,18 +88,14 @@ class TestBasicRequests:
         assert not response.is_redirect
 
         assert response.url == target_url
-    
+
     def test_limit_redirects(self, browser: Browser) -> None:
         impit = Client(browser=browser, follow_redirects=True, max_redirects=1)
 
-        redirect_url = get_httpbin_url(f'/absolute-redirect/3')
-        
-        try:
-            response = impit.get(redirect_url)
-        except Exception as e:
-            assert isinstance(e, RuntimeError)
-            assert 'TooManyRedirects' in str(e)
-            return
+        redirect_url = get_httpbin_url('/absolute-redirect/3')
+
+        with pytest.raises(RuntimeError, match='TooManyRedirects'):
+            impit.get(redirect_url)
 
 
 @pytest.mark.parametrize(

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -62,7 +62,7 @@ class TestBasicRequests:
 
         m('https://example.org')
 
-    async def test_url_with_redirect(self, browser: Browser) -> None:
+    def test_default_no_redirect(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 
         target_url = get_httpbin_url('/')
@@ -70,12 +70,36 @@ class TestBasicRequests:
 
         response = impit.get(redirect_url)
 
-        assert response.status_code == 200
-        assert response.url == target_url
-        assert response.url != redirect_url
+        assert response.status_code == 302
+        assert response.is_redirect
 
-        # The target page does not have a redirect status
+        assert response.url == redirect_url
+        assert response.headers.get('location') == target_url
+
+    def test_follow_redirects(self, browser: Browser) -> None:
+        impit = Client(browser=browser, follow_redirects=True)
+
+        target_url = get_httpbin_url('/')
+        redirect_url = get_httpbin_url(f'/redirect-to?{urlencode({"url": target_url})}')
+
+        response = impit.get(redirect_url)
+
+        assert response.status_code == 200
         assert not response.is_redirect
+
+        assert response.url == target_url
+    
+    def test_limit_redirects(self, browser: Browser) -> None:
+        impit = Client(browser=browser, follow_redirects=True, max_redirects=1)
+
+        redirect_url = get_httpbin_url(f'/absolute-redirect/3')
+        
+        try:
+            response = impit.get(redirect_url)
+        except Exception as e:
+            assert isinstance(e, RuntimeError)
+            assert 'TooManyRedirects' in str(e)
+            return
 
 
 @pytest.mark.parametrize(

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -66,7 +66,7 @@ class TestBasicRequests:
         impit = Client(browser=browser)
 
         target_url = get_httpbin_url('/')
-        redirect_url = get_httpbin_url(f'/redirect-to?{urlencode({"url": target_url})}')
+        redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
 
         response = impit.get(redirect_url)
 
@@ -80,7 +80,7 @@ class TestBasicRequests:
         impit = Client(browser=browser, follow_redirects=True)
 
         target_url = get_httpbin_url('/')
-        redirect_url = get_httpbin_url(f'/redirect-to?{urlencode({"url": target_url})}')
+        redirect_url = get_httpbin_url(f'/redirect-to', query={'url': target_url})
 
         response = impit.get(redirect_url)
 

--- a/impit-python/test/httpbin.py
+++ b/impit-python/test/httpbin.py
@@ -6,7 +6,7 @@ def get_httpbin_url(path: str, *, query: dict[str, str] = {}, https: bool = True
     url = None
     if os.environ.get('APIFY_HTTPBIN_TOKEN'):
         url = urllib.parse.urlparse('https://httpbin.apify.actor')
-        query['token'] = [os.environ['APIFY_HTTPBIN_TOKEN']]
+        query['token'] = os.environ['APIFY_HTTPBIN_TOKEN']
         url = url._replace(query=urllib.parse.urlencode(query, doseq=True))
     else:
         url = urllib.parse.urlparse('https://httpbin.org')

--- a/impit-python/test/httpbin.py
+++ b/impit-python/test/httpbin.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import os
 import urllib.parse
 
 
-def get_httpbin_url(path: str, *, query: dict[str, str] = {}, https: bool = True) -> str:
+def get_httpbin_url(path: str, *, query: dict[str, str] | None = None, https: bool = True) -> str:
+    query = query or {}
     url = None
     if os.environ.get('APIFY_HTTPBIN_TOKEN'):
         url = urllib.parse.urlparse('https://httpbin.apify.actor')

--- a/impit-python/test/httpbin.py
+++ b/impit-python/test/httpbin.py
@@ -2,11 +2,10 @@ import os
 import urllib.parse
 
 
-def get_httpbin_url(path: str, *, https: bool = True) -> str:
+def get_httpbin_url(path: str, *, query: dict[str, str] = {}, https: bool = True) -> str:
     url = None
     if os.environ.get('APIFY_HTTPBIN_TOKEN'):
         url = urllib.parse.urlparse('https://httpbin.apify.actor')
-        query = urllib.parse.parse_qs(url.query)
         query['token'] = [os.environ['APIFY_HTTPBIN_TOKEN']]
         url = url._replace(query=urllib.parse.urlencode(query, doseq=True))
     else:

--- a/impit/src/lib.rs
+++ b/impit/src/lib.rs
@@ -89,5 +89,6 @@ pub mod emulation {
 pub mod utils {
     pub use crate::response_parsing::decode;
     pub use crate::response_parsing::ContentType;
+    pub use crate::response_parsing::determine_encoding;
     pub use encoding::all as encodings;
 }

--- a/impit/src/lib.rs
+++ b/impit/src/lib.rs
@@ -88,7 +88,7 @@ pub mod emulation {
 /// Various utility functions and types.
 pub mod utils {
     pub use crate::response_parsing::decode;
-    pub use crate::response_parsing::ContentType;
     pub use crate::response_parsing::determine_encoding;
+    pub use crate::response_parsing::ContentType;
     pub use encoding::all as encodings;
 }

--- a/impit/src/response_parsing/mod.rs
+++ b/impit/src/response_parsing/mod.rs
@@ -89,20 +89,31 @@ fn prescan_bytestream(bytes: &[u8]) -> Option<encoding::EncodingRef> {
 ///
 /// assert_eq!(string, "žluťoučký kůň"); // The function uses the Windows-1250 encoding.
 /// ```
-pub fn decode(bytes: &[u8], encoding_prior_knowledge: Option<encoding::EncodingRef>) -> String {
-    let mut encoding: encoding::EncodingRef = encoding::all::UTF_8;
-
-    if let Some(enc) = encoding_prior_knowledge {
-        encoding = enc;
-    } else if let Some(enc) = bom_sniffing(bytes) {
-        encoding = enc;
-    } else if let Some(enc) = prescan_bytestream(bytes) {
-        encoding = enc;
-    }
+pub fn decode(bytes: &[u8], preferred_encoding: Option<encoding::EncodingRef>) -> String {
+    let encoding = match preferred_encoding {
+        Some(encoding) => encoding,
+        None => determine_encoding(bytes).unwrap_or(encoding::all::UTF_8),
+    };
 
     encoding
         .decode(bytes, encoding::DecoderTrap::Replace)
         .unwrap()
+}
+
+/// Determines the encoding of a byte stream.
+/// 
+/// If the checks fail, the function returns `None`.
+pub fn determine_encoding(
+    bytes: &[u8],
+) -> Option<encoding::EncodingRef> {
+
+    if let Some(enc) = bom_sniffing(bytes) {
+        return Some(enc);
+    } else if let Some(enc) = prescan_bytestream(bytes) {
+        return Some(enc);
+    }
+
+    None
 }
 
 /// A struct that represents the contents of the `Content-Type` header.

--- a/impit/src/response_parsing/mod.rs
+++ b/impit/src/response_parsing/mod.rs
@@ -101,12 +101,9 @@ pub fn decode(bytes: &[u8], preferred_encoding: Option<encoding::EncodingRef>) -
 }
 
 /// Determines the encoding of a byte stream.
-/// 
+///
 /// If the checks fail, the function returns `None`.
-pub fn determine_encoding(
-    bytes: &[u8],
-) -> Option<encoding::EncodingRef> {
-
+pub fn determine_encoding(bytes: &[u8]) -> Option<encoding::EncodingRef> {
     if let Some(enc) = bom_sniffing(bytes) {
         return Some(enc);
     } else if let Some(enc) = prescan_bytestream(bytes) {


### PR DESCRIPTION
- add `url` property for `Response`
- add `content` property for `Response`