### PR TITLE
fix: case-insensitive request header deduplication

### DIFF
--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -71,6 +71,20 @@ describe.each([
             t.expect(json.headers?.['Impit-Test']).toBe('foo');
         })
 
+        test('overwriting impersonated headers works', async (t) => {
+            const response = await impit.fetch(
+            getHttpBinUrl('/headers'),
+            {
+                headers: {
+                    'User-Agent': 'this is impit!',
+                }
+            }
+            );
+            const json = await response.json();
+
+            t.expect(json.headers?.['User-Agent']).toBe('this is impit!');
+        })
+
         test('http3 works', async (t) => {
             const impit = new Impit({
                 http3: true,

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -38,6 +38,16 @@ class TestBasicRequests:
         assert json.loads(response.text)['headers']['Impit-Test'] == 'foo'
 
     @pytest.mark.asyncio
+    async def test_overwriting_headers_work(self, browser: Browser) -> None:
+        impit = AsyncClient(browser=browser)
+
+        response = await impit.get(
+            get_httpbin_url('/headers'), headers={'User-Agent': 'this is impit!'}
+        )
+        assert response.status_code == 200
+        assert json.loads(response.text)['headers']['User-Agent'] == 'this is impit!'
+
+    @pytest.mark.asyncio
     async def test_http3_works(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser, http3=True)
 

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -41,9 +41,7 @@ class TestBasicRequests:
     async def test_overwriting_headers_work(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser)
 
-        response = await impit.get(
-            get_httpbin_url('/headers'), headers={'User-Agent': 'this is impit!'}
-        )
+        response = await impit.get(get_httpbin_url('/headers'), headers={'User-Agent': 'this is impit!'})
         assert response.status_code == 200
         assert json.loads(response.text)['headers']['User-Agent'] == 'this is impit!'
 

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -42,6 +42,15 @@ class TestBasicRequests:
         assert response.status_code == 200
         assert json.loads(response.text)['headers']['Impit-Test'] == 'foo'
 
+    def test_overwriting_headers_work(self, browser: Browser) -> None:
+        impit = Client(browser=browser)
+
+        response = impit.get(
+            get_httpbin_url('/headers'), headers={'User-Agent': 'this is impit!'}
+        )
+        assert response.status_code == 200
+        assert json.loads(response.text)['headers']['User-Agent'] == 'this is impit!'
+
     def test_http3_works(self, browser: Browser) -> None:
         impit = Client(browser=browser, http3=True)
 

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -45,9 +45,7 @@ class TestBasicRequests:
     def test_overwriting_headers_work(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 
-        response = impit.get(
-            get_httpbin_url('/headers'), headers={'User-Agent': 'this is impit!'}
-        )
+        response = impit.get(get_httpbin_url('/headers'), headers={'User-Agent': 'this is impit!'})
         assert response.status_code == 200
         assert json.loads(response.text)['headers']['User-Agent'] == 'this is impit!'
 

--- a/impit/src/http_headers/mod.rs
+++ b/impit/src/http_headers/mod.rs
@@ -1,6 +1,6 @@
 use crate::emulation::Browser;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::{HashMap, HashSet}, str::FromStr};
 
 mod statics;
 
@@ -22,13 +22,15 @@ impl HttpHeaders {
 
 impl From<HttpHeaders> for HeaderMap {
     fn from(val: HttpHeaders) -> Self {
-        let mut headers = HeaderMap::new();
-
-        let header_values = match val.context.browser {
+        let impersonated_headers = match val.context.browser {
             Some(Browser::Chrome) => statics::CHROME_HEADERS,
             Some(Browser::Firefox) => statics::FIREFOX_HEADERS,
             None => &[],
-        };
+        }.to_owned();
+
+        let custom_headers = val.context.custom_headers
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()));
 
         let pseudo_headers_order: &[&str] = match val.context.browser {
             Some(Browser::Chrome) => statics::CHROME_PSEUDOHEADERS_ORDER.as_ref(),
@@ -43,33 +45,18 @@ impl From<HttpHeaders> for HeaderMap {
             );
         }
 
-        let mut used_custom_headers: Vec<String> = vec![];
+        let mut headers = HeaderMap::new();
 
-        // TODO: don't use HTTP2 headers for HTTP1.1
-        for (name, impersonated_value) in header_values {
-            let value: &str = match val.context.custom_headers.get(*name) {
-                Some(custom_value) => {
-                    used_custom_headers.push(name.to_string());
-                    custom_value.as_str()
-                }
-                None => impersonated_value,
-            };
+        let mut used_header_names: HashSet<String> = HashSet::new();
 
-            headers.append(
-                HeaderName::from_str(name).unwrap(),
-                HeaderValue::from_str(value).unwrap(),
-            );
-        }
-
-        val.context.custom_headers.iter().for_each(|(name, value)| {
-            if !used_custom_headers.contains(name) {
-                headers.append(
-                    HeaderName::from_str(name).unwrap(),
-                    HeaderValue::from_str(value).unwrap(),
-                );
+        for (name, value) in custom_headers.chain(impersonated_headers) {
+            if used_header_names.contains(&name.to_lowercase()) {
+                continue;
             }
-        });
 
+            headers.append(HeaderName::from_str(name).unwrap(), HeaderValue::from_str(value).unwrap());
+            used_header_names.insert(name.to_lowercase());
+        }
         headers
     }
 }

--- a/impit/src/http_headers/mod.rs
+++ b/impit/src/http_headers/mod.rs
@@ -1,6 +1,9 @@
 use crate::emulation::Browser;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use std::{collections::{HashMap, HashSet}, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 
 mod statics;
 
@@ -26,9 +29,12 @@ impl From<HttpHeaders> for HeaderMap {
             Some(Browser::Chrome) => statics::CHROME_HEADERS,
             Some(Browser::Firefox) => statics::FIREFOX_HEADERS,
             None => &[],
-        }.to_owned();
+        }
+        .to_owned();
 
-        let custom_headers = val.context.custom_headers
+        let custom_headers = val
+            .context
+            .custom_headers
             .iter()
             .map(|(k, v)| (k.as_str(), v.as_str()));
 
@@ -54,7 +60,10 @@ impl From<HttpHeaders> for HeaderMap {
                 continue;
             }
 
-            headers.append(HeaderName::from_str(name).unwrap(), HeaderValue::from_str(value).unwrap());
+            headers.append(
+                HeaderName::from_str(name).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
             used_header_names.insert(name.to_lowercase());
         }
         headers


### PR DESCRIPTION
Refactors and simplifies the custom header logic. Custom headers now override "impersonated" browser headers regardless on the (upper|lower)case.

closes #96 