### PR TITLE
fix: set `response.text()` return type to `string`

### DIFF
--- a/impit-node/index.d.ts
+++ b/impit-node/index.d.ts
@@ -13,9 +13,9 @@ export declare class ImpitResponse {
   headers: Record<string, string>
   ok: boolean
   url: string
-  decodeBuffer(buffer: Buffer): String
+  decodeBuffer(buffer: Buffer): string
   bytes(this: object): Promise<Uint8Array>
-  text(this: object): Promise<String>
+  text(this: object): Promise<string>
   json(this: object): Promise<any>
   get body(): ReadableStream<Uint8Array>
 }

--- a/impit-node/src/response.rs
+++ b/impit-node/src/response.rs
@@ -108,7 +108,7 @@ impl ImpitResponse {
     Ok(this.get(INNER_RESPONSE_PROPERTY_NAME)?.unwrap())
   }
 
-  #[napi(ts_return_type = "String")]
+  #[napi(ts_return_type = "string")]
   pub fn decode_buffer(&self, buffer: Buffer) -> Result<String> {
     let encoding = self
       .headers
@@ -135,7 +135,7 @@ impl ImpitResponse {
       .call_without_args(Some(&response))
   }
 
-  #[napi(ts_return_type = "Promise<String>")]
+  #[napi(ts_return_type = "Promise<string>")]
   pub fn text(&self, env: &Env, this: This<JsObject>) -> Result<JsUnknown> {
     let response = self.get_inner_response(env, this)?;
 

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -162,14 +162,14 @@ describe.each([
     describe('Response parsing', () => {
         test('.text() method works', async (t) => {
             const response = await impit.fetch(getHttpBinUrl('/html'));
-            const text = await response.text();
+            const text: string = await response.text();
 
             t.expect(text).toContain('Herman Melville');
         });
 
         test('.text() method works with decoding', async (t) => {
             const response = await impit.fetch(new URL(routes.charset.path, "http://127.0.0.1:3001").href);
-            const text = await response.text();
+            const text: string = await response.text();
 
             t.expect(text).toContain(routes.charset.bodyString);
         });


### PR DESCRIPTION
The type definitions for `response.text()` return type used `String` (see capital S) instead of `string` (like `fetch` API does). Note that this is a strictly type-level issue and simple cast (or type change, in this case) solves this.

Closes #135 