### PR TITLE
feat(js): `response.headers` is a `Headers` object

### DIFF
--- a/impit-node/index.d.ts
+++ b/impit-node/index.d.ts
@@ -10,7 +10,7 @@ export type ImpitWrapper = Impit
 export declare class ImpitResponse {
   status: number
   statusText: string
-  headers: Record<string, string>
+  headers: Headers
   ok: boolean
   url: string
   decodeBuffer(buffer: Buffer): String

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -5,6 +5,10 @@ class ResponsePatches {
         const buffer = await this.bytes();
         return this.decodeBuffer(buffer);
     }
+
+    static headers(headers) {
+        return new Headers(headers);
+    }
 }
 
 class Impit extends native.Impit {
@@ -13,6 +17,10 @@ class Impit extends native.Impit {
 
         Object.defineProperty(originalResponse, 'text', {
             value: ResponsePatches.text.bind(originalResponse)
+        });
+
+        Object.defineProperty(originalResponse, 'headers', {
+            value: ResponsePatches.headers(originalResponse.headers)
         });
 
         return originalResponse;

--- a/impit-node/src/response.rs
+++ b/impit-node/src/response.rs
@@ -17,7 +17,7 @@ pub struct ImpitResponse {
   inner: RefCell<Option<Response>>,
   pub status: u16,
   pub status_text: String,
-  #[napi(ts_type = "Record<string, string>")]
+  #[napi(ts_type = "Headers")]
   pub headers: Headers,
   pub ok: bool,
   pub url: String,

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -61,14 +61,19 @@ describe.each([
             getHttpBinUrl('/headers'),
             {
                 headers: {
-                'Impit-Test': 'foo',
-                'Cookie': 'test=123; test2=456'
+                    'Impit-Test': 'foo',
+                    'Cookie': 'test=123; test2=456'
                 }
             }
             );
             const json = await response.json();
+            const headers = response.headers;
 
+            // request headers
             t.expect(json.headers?.['Impit-Test']).toBe('foo');
+
+            // response headers
+            t.expect(headers.get('content-type')).toEqual('application/json');
         })
 
         test('overwriting impersonated headers works', async (t) => {


### PR DESCRIPTION
Turns the `response.headers` from a `Record<string, string>` into a `Headers` object, matching the original `fetch` API.

Closes #134 