### PR TITLE
fix(js): do not publish ambient `const enum`s

### DIFF
--- a/impit-node/index.d.ts
+++ b/impit-node/index.d.ts
@@ -20,20 +20,16 @@ export declare class ImpitResponse {
   get body(): ReadableStream<Uint8Array>
 }
 
-export declare const enum Browser {
-  Chrome = 'Chrome',
-  Firefox = 'Firefox'
-}
+export type Browser =  'chrome'|
+'firefox';
 
-export declare const enum HttpMethod {
-  Get = 'GET',
-  Post = 'POST',
-  Put = 'PUT',
-  Delete = 'DELETE',
-  Patch = 'PATCH',
-  Head = 'HEAD',
-  Options = 'OPTIONS'
-}
+export type HttpMethod =  'GET'|
+'POST'|
+'PUT'|
+'DELETE'|
+'PATCH'|
+'HEAD'|
+'OPTIONS';
 
 export interface ImpitOptions {
   browser?: Browser

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -37,8 +37,8 @@
   },
   "scripts": {
     "artifacts": "napi artifacts --output-dir ../artifacts --npm-dir npm",
-    "build": "napi build --platform --release",
-    "build:debug": "napi build --platform",
+    "build": "napi build --platform --release --no-const-enum",
+    "build:debug": "napi build --platform --no-const-enum",
     "prepublishOnly": "napi prepublish -t npm --no-gh-release",
     "test": "vitest --retry=3",
     "universal": "napi universal",

--- a/impit-node/src/impit_builder.rs
+++ b/impit-node/src/impit_builder.rs
@@ -6,7 +6,7 @@ use impit::{
 };
 use napi_derive::napi;
 
-#[napi(string_enum)]
+#[napi(string_enum = "lowercase")]
 pub enum Browser {
   Chrome,
   Firefox,


### PR DESCRIPTION
Switches from exporting `const enum`s from the `.d.ts` file ([which is problematic](https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls)) to exporting union types. 

Makes the `browser` option accept lowercase browser names.

Closes #133