### PR TITLE
chore(js): add proxy usage tests

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -211,6 +211,7 @@ jobs:
       - name: Test bindings
         env:
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
+            PROXY_PASSWORD: ${{ secrets.APIFY_TEST_USER_PROXY_PASSWORD }}
         run: yarn --cwd impit-node test
   test-linux-x64-gnu-binding:
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}
@@ -251,7 +252,10 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: docker run -e CI=1 -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }} --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim sh -c "corepack enable && yarn --cwd impit-node test"
+        run: docker run -e CI=1 -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }} -e PROXY_PASSWORD=${{ secrets.APIFY_TEST_USER_PROXY_PASSWORD }} --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim sh -c "corepack enable && yarn --cwd impit-node test"
+      - name: Additional test step
+        run: echo "Running additional tests"
+        shell: bash
 
   test-linux-aarch64-gnu-binding:
     name: Test bindings on Linux-aarch64-gnu - node@${{ matrix.node }}
@@ -295,6 +299,7 @@ jobs:
       - name: Test bindings
         env:
             APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
+            PROXY_PASSWORD: ${{ secrets.APIFY_TEST_USER_PROXY_PASSWORD }}
         run: yarn --cwd impit-node test
 
   test-linux-aarch64-musl-binding:
@@ -336,7 +341,7 @@ jobs:
         shell: bash
       - name: Test bindings
         run: |
-          docker run -e CI=1 -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }} --rm -v $(pwd):/build -w /build arm64v8/node:${{ matrix.node }}-alpine sh -c "corepack enable && yarn --cwd impit-node install && yarn --cwd impit-node test"
+          docker run -e CI=1 -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }} -e PROXY_PASSWORD=${{ secrets.APIFY_TEST_USER_PROXY_PASSWORD }} --rm -v $(pwd):/build -w /build arm64v8/node:${{ matrix.node }}-alpine sh -c "corepack enable && yarn --cwd impit-node install && yarn --cwd impit-node test"
 
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
@@ -377,5 +382,5 @@ jobs:
         shell: bash
       - name: Test bindings
         run: |
-          docker run -e CI=1 -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }} --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-alpine sh -c "corepack enable && yarn --cwd impit-node install && yarn --cwd impit-node test"
+          docker run -e CI=1 -e APIFY_HTTPBIN_TOKEN=${{ secrets.APIFY_HTTPBIN_TOKEN }} -e PROXY_PASSWORD=${{ secrets.APIFY_TEST_USER_PROXY_PASSWORD }} --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-alpine sh -c "corepack enable && yarn --cwd impit-node install && yarn --cwd impit-node test"
 

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -47,13 +47,13 @@
   "packageManager": "yarn@4.9.1",
   "description": "Impit for JavaScript",
   "optionalDependencies": {
-    "impit-darwin-x64": "0.4.0",
     "impit-darwin-arm64": "0.4.0",
-    "impit-win32-x64-msvc": "0.4.0",
-    "impit-win32-arm64-msvc": "0.4.0",
+    "impit-darwin-x64": "0.4.0",
+    "impit-linux-arm64-gnu": "0.4.0",
+    "impit-linux-arm64-musl": "0.4.0",
     "impit-linux-x64-gnu": "0.4.0",
     "impit-linux-x64-musl": "0.4.0",
-    "impit-linux-arm64-gnu": "0.4.0",
-    "impit-linux-arm64-musl": "0.4.0"
+    "impit-win32-arm64-msvc": "0.4.0",
+    "impit-win32-x64-msvc": "0.4.0"
   }
 }

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -3,6 +3,7 @@ import { test, describe, expect, beforeAll, afterAll } from 'vitest';
 import { HttpMethod, Impit, Browser } from '../index.wrapper.js';
 import { Server } from 'http';
 import { routes, runServer } from './mock.server.js';
+import { deepStrictEqual } from 'assert';
 
 function getHttpBinUrl(path: string, https?: boolean): string {
     https ??= true;
@@ -226,6 +227,21 @@ describe.each([
         }
 
         t.expect(found).toBe(true);
+        });
+    });
+
+    describe('Proxy', () => {
+        test('proxy works', async (t) => {
+            const impit = new Impit({
+                proxyUrl: `http://auto:${process.env.PROXY_PASSWORD}@proxy.apify.com:8000`,
+                browser,
+            });
+
+            const response = await impit.fetch(
+                getHttpBinUrl('/headers')
+            );
+
+            await response.text();
         });
     });
 

--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -2354,58 +2354,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.3.2":
-  version: 0.3.2
-  resolution: "impit-darwin-arm64@npm:0.3.2"
+"impit-darwin-arm64@npm:0.4.0":
+  version: 0.4.0
+  resolution: "impit-darwin-arm64@npm:0.4.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.3.2":
-  version: 0.3.2
-  resolution: "impit-darwin-x64@npm:0.3.2"
+"impit-darwin-x64@npm:0.4.0":
+  version: 0.4.0
+  resolution: "impit-darwin-x64@npm:0.4.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.3.2":
-  version: 0.3.2
-  resolution: "impit-linux-arm64-gnu@npm:0.3.2"
+"impit-linux-arm64-gnu@npm:0.4.0":
+  version: 0.4.0
+  resolution: "impit-linux-arm64-gnu@npm:0.4.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.3.2":
-  version: 0.3.2
-  resolution: "impit-linux-arm64-musl@npm:0.3.2"
+"impit-linux-arm64-musl@npm:0.4.0":
+  version: 0.4.0
+  resolution: "impit-linux-arm64-musl@npm:0.4.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.3.2":
-  version: 0.3.2
-  resolution: "impit-linux-x64-gnu@npm:0.3.2"
+"impit-linux-x64-gnu@npm:0.4.0":
+  version: 0.4.0
+  resolution: "impit-linux-x64-gnu@npm:0.4.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.3.2":
-  version: 0.3.2
-  resolution: "impit-linux-x64-musl@npm:0.3.2"
+"impit-linux-x64-musl@npm:0.4.0":
+  version: 0.4.0
+  resolution: "impit-linux-x64-musl@npm:0.4.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.3.2":
-  version: 0.3.2
-  resolution: "impit-win32-arm64-msvc@npm:0.3.2"
+"impit-win32-arm64-msvc@npm:0.4.0":
+  version: 0.4.0
+  resolution: "impit-win32-arm64-msvc@npm:0.4.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.3.2":
-  version: 0.3.2
-  resolution: "impit-win32-x64-msvc@npm:0.3.2"
+"impit-win32-x64-msvc@npm:0.4.0":
+  version: 0.4.0
+  resolution: "impit-win32-x64-msvc@npm:0.4.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2418,14 +2418,14 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^22.13.1"
     express: "npm:^5.0.0"
-    impit-darwin-arm64: "npm:0.3.2"
-    impit-darwin-x64: "npm:0.3.2"
-    impit-linux-arm64-gnu: "npm:0.3.2"
-    impit-linux-arm64-musl: "npm:0.3.2"
-    impit-linux-x64-gnu: "npm:0.3.2"
-    impit-linux-x64-musl: "npm:0.3.2"
-    impit-win32-arm64-msvc: "npm:0.3.2"
-    impit-win32-x64-msvc: "npm:0.3.2"
+    impit-darwin-arm64: "npm:0.4.0"
+    impit-darwin-x64: "npm:0.4.0"
+    impit-linux-arm64-gnu: "npm:0.4.0"
+    impit-linux-arm64-musl: "npm:0.4.0"
+    impit-linux-x64-gnu: "npm:0.4.0"
+    impit-linux-x64-musl: "npm:0.4.0"
+    impit-win32-arm64-msvc: "npm:0.4.0"
+    impit-win32-x64-msvc: "npm:0.4.0"
     vitest: "npm:^3.0.5"
   dependenciesMeta:
     impit-darwin-arm64:


### PR DESCRIPTION
Comments under https://github.com/apify/camoufox-js/issues/16 suggest that impit doesn't work as expected with proxies on Windows. This PR adds tests to verify this.