### PR TITLE
feat: switch to `Vec<(String, String)>` for request headers

### DIFF
--- a/impit-cli/src/headers.rs
+++ b/impit-cli/src/headers.rs
@@ -1,14 +1,15 @@
-use std::collections::HashMap;
-
-pub(crate) fn process_headers(headers: Vec<String>) -> HashMap<String, String> {
-    let mut map = HashMap::new();
-
-    for header in headers {
-        let mut parts = header.splitn(2, ':');
-        let key = parts.next().unwrap().trim().to_string();
-        let value = parts.next().unwrap().trim().to_string();
-        map.insert(key, value);
-    }
-
-    map
+pub(crate) fn process_headers(headers: Vec<String>) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|header| {
+            let parts: Vec<&str> = header.split(':').collect();
+            if parts.len() == 2 {
+                let key = parts[0].trim().to_string();
+                let value = parts[1].trim().to_string();
+                (key, value)
+            } else {
+                ("".to_string(), "".to_string())
+            }
+        })
+        .collect()
 }

--- a/impit-node/index.d.ts
+++ b/impit-node/index.d.ts
@@ -52,7 +52,7 @@ export interface ImpitOptions {
 
 export interface RequestInit {
   method?: HttpMethod
-  headers?: Record<string, string>
+  headers?: Headers | Record<string, string> | [string, string][]
   body?: string | Buffer
   /** Request timeout in milliseconds. Overrides the Impit-wide timeout option. */
   timeout?: number

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -9,10 +9,12 @@ class ResponsePatches {
 
 class Impit extends native.Impit {
     async fetch(url, options) {
-        if (options.headers instanceof Headers) {
-            options.headers = options.headers.entries();
-        } else if (!Array.isArray(options.headers)) {
-            options.headers = Object.entries(options.headers || {});
+        if (options?.headers) {
+            if (options.headers instanceof Headers) {
+                options.headers = [...options.headers.entries()];
+            } else if (!Array.isArray(options.headers)) {
+                options.headers = Object.entries(options.headers || {});
+            }
         }
         
         const originalResponse = await super.fetch(url, options);

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -9,6 +9,12 @@ class ResponsePatches {
 
 class Impit extends native.Impit {
     async fetch(url, options) {
+        if (options.headers instanceof Headers) {
+            options.headers = options.headers.entries();
+        } else if (!Array.isArray(options.headers)) {
+            options.headers = Object.entries(options.headers || {});
+        }
+        
         const originalResponse = await super.fetch(url, options);
 
         Object.defineProperty(originalResponse, 'text', {

--- a/impit-node/src/request.rs
+++ b/impit-node/src/request.rs
@@ -1,6 +1,5 @@
 use napi::{bindgen_prelude::Buffer, Either};
 use napi_derive::napi;
-use std::collections::HashMap;
 
 #[derive(Default)]
 #[napi(string_enum = "UPPERCASE")]
@@ -26,7 +25,8 @@ pub(crate) fn serialize_body(body: &Either<String, Buffer>) -> Vec<u8> {
 #[napi(object)]
 pub struct RequestInit {
   pub method: Option<HttpMethod>,
-  pub headers: Option<HashMap<String, String>>,
+  #[napi(ts_type = "Headers | Record<string, string> | [string, string][]")]
+  pub headers: Option<Vec<(String, String)>>,
   pub body: Option<Either<String, Buffer>>,
   /// Request timeout in milliseconds. Overrides the Impit-wide timeout option.
   pub timeout: Option<u32>,

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -56,24 +56,36 @@ describe.each([
             await expect(response).resolves.toBeTruthy();
         });
 
-        test('headers work', async (t) => {
+        test.each(
+            [
+            ['object', {
+                'Impit-Test': 'foo',
+                'Cookie': 'test=123; test2=456'
+            }],
+            ['array', [
+                ['Impit-Test', 'foo'],
+                ['Cookie', 'test=123; test2=456']
+            ]],
+            ['Headers', new Headers([
+                ['Impit-Test', 'foo'],
+                ['Cookie', 'test=123; test2=456']
+            ])],
+            ]
+        )('headers (%s) work', async (_, value) => {
             const response = await impit.fetch(
             getHttpBinUrl('/headers'),
             {
-                headers: {
-                    'Impit-Test': 'foo',
-                    'Cookie': 'test=123; test2=456'
-                }
+                headers: value
             }
             );
             const json = await response.json();
             const headers = response.headers;
 
             // request headers
-            t.expect(json.headers?.['Impit-Test']).toBe('foo');
+            expect(json.headers?.['Impit-Test']).toBe('foo');
 
             // response headers
-            t.expect(headers.get('content-type')).toEqual('application/json');
+            expect(headers.get('content-type')).toEqual('application/json');
         })
 
         test('multiple same-named response headers work', async (t) => {

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -280,7 +280,11 @@ impl AsyncClient {
         }?;
 
         let options = RequestOptions {
-            headers: headers.unwrap_or_default(),
+            headers: headers
+                .unwrap_or_default()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
             timeout: timeout.map(Duration::from_secs_f64),
             http3_prior_knowledge: force_http3.unwrap_or(false),
         };

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -221,7 +221,11 @@ impl Client {
         }?;
 
         let options = RequestOptions {
-            headers: headers.unwrap_or_default(),
+            headers: headers
+                .unwrap_or_default()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
             timeout: timeout.map(Duration::from_secs_f64),
             http3_prior_knowledge: force_http3.unwrap_or(false),
         };

--- a/impit/src/http_headers/mod.rs
+++ b/impit/src/http_headers/mod.rs
@@ -1,9 +1,6 @@
 use crate::emulation::Browser;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use std::{
-    collections::{HashMap, HashSet},
-    str::FromStr,
-};
+use std::{collections::HashSet, str::FromStr};
 
 mod statics;
 
@@ -75,7 +72,7 @@ pub struct HttpHeadersBuilder {
     host: String,
     browser: Option<Browser>,
     https: bool,
-    custom_headers: HashMap<String, String>,
+    custom_headers: Vec<(String, String)>,
 }
 
 impl HttpHeadersBuilder {
@@ -95,7 +92,7 @@ impl HttpHeadersBuilder {
         self
     }
 
-    pub fn with_custom_headers(&mut self, custom_headers: &HashMap<String, String>) -> &mut Self {
+    pub fn with_custom_headers(&mut self, custom_headers: &Vec<(String, String)>) -> &mut Self {
         self.custom_headers = custom_headers.to_owned();
         self
     }

--- a/impit/src/request.rs
+++ b/impit/src/request.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 /// A struct that holds the request options.
 ///
@@ -7,8 +7,8 @@ use std::{collections::HashMap, time::Duration};
 /// Used by the [`Impit`](crate::impit::Impit) struct's methods.
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {
-    /// A `HashMap` that holds custom HTTP headers. These are added to the default headers and should never overwrite them.
-    pub headers: HashMap<String, String>,
+    /// A `Vec` of string pairs that represent custom HTTP request headers. These are added to the default headers.
+    pub headers: Vec<(String, String)>,
     /// The timeout for the request. This option overrides the global [`Impit`] timeout.
     pub timeout: Option<Duration>,
     /// Enforce the use of HTTP/3 for this request. This will cause broken responses from servers that don't support HTTP/3.


### PR DESCRIPTION
Allows sending multiple request headers of the same name across all bindings / tools.

Broadens the `RequestInit.headers` type in the `impit-node` bindings. Closes #151 