### PR TITLE
chore: remove commit SHA from changelog generation

### DIFF
--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -108,7 +108,6 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-depth: 0
-            ref: ${{ needs.publish.outputs.bumped-version-commit-sha }}
   
         - name: Generate a changelog
           uses: orhun/git-cliff-action@v4

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -112,7 +112,6 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-depth: 0
-            ref: ${{ needs.get_version.outputs.bumped-version-commit-sha }}
   
         - name: Generate a changelog
           uses: orhun/git-cliff-action@v4


### PR DESCRIPTION
Fixes failing changelog-generating GitHub Action by pulling the default branch.