### PR TITLE
fix: render helpful error message on import errors

### DIFF
--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -13,8 +13,8 @@ This can have several reasons:
         If you still want to skip installing other optional dependencies, please install the native bindings for your platform as a direct dependency of your project.
 - You are using a non-standard Node.js runtime (e.g. Deno, Bun, Cloudflare workers etc.) that might not support native modules.
 
-Run your script with IMPIT_IMPORT_VERBOSE_ERROR=1 environment variable to get more information about the error.
-`, process.env['IMPIT_IMPORT_VERBOSE_ERROR'] === '1' ? { cause: e } : undefined);
+Run your script with IMPIT_VERBOSE=1 environment variable to get more information about the error.
+`, process.env['IMPIT_VERBOSE'] === '1' ? { cause: e } : undefined);
 }
 
 class ResponsePatches {

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -1,5 +1,21 @@
 const { castToTypedArray } = require('./request.js');
-const native = require('./index.js');
+let native = null;
+try {
+    native = require('./index.js');
+} catch (e) {
+    throw new Error(`
+impit couldn't load native bindings. 
+
+This can have several reasons:
+- The native bindings are not compiled for your platform (${process.platform}-${process.arch}).
+- You skipped installation of optional dependencies (using e.g. \`npm i --omit=optional\`).
+        While the main package (impit) still installs, your package manager will skip installing the prebuilt native bindings for your platform.
+        If you still want to skip installing other optional dependencies, please install the native bindings for your platform as a direct dependency of your project.
+- You are using a non-standard Node.js runtime (e.g. Deno, Bun, Cloudflare workers etc.) that might not support native modules.
+
+Run your script with IMPIT_IMPORT_VERBOSE_ERROR=1 environment variable to get more information about the error.
+`, process.env['IMPIT_IMPORT_VERBOSE_ERROR'] === '1' ? { cause: e } : undefined);
+}
 
 class ResponsePatches {
     static async text() {

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -47,13 +47,13 @@
   "packageManager": "yarn@4.9.1",
   "description": "Impit for JavaScript",
   "optionalDependencies": {
-    "impit-darwin-x64": "0.4.4",
     "impit-darwin-arm64": "0.4.4",
-    "impit-win32-x64-msvc": "0.4.4",
-    "impit-win32-arm64-msvc": "0.4.4",
+    "impit-darwin-x64": "0.4.4",
+    "impit-linux-arm64-gnu": "0.4.4",
+    "impit-linux-arm64-musl": "0.4.4",
     "impit-linux-x64-gnu": "0.4.4",
     "impit-linux-x64-musl": "0.4.4",
-    "impit-linux-arm64-gnu": "0.4.4",
-    "impit-linux-arm64-musl": "0.4.4"
+    "impit-win32-arm64-msvc": "0.4.4",
+    "impit-win32-x64-msvc": "0.4.4"
   }
 }

--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -2354,58 +2354,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.4.3":
-  version: 0.4.3
-  resolution: "impit-darwin-arm64@npm:0.4.3"
+"impit-darwin-arm64@npm:0.4.4":
+  version: 0.4.4
+  resolution: "impit-darwin-arm64@npm:0.4.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.4.3":
-  version: 0.4.3
-  resolution: "impit-darwin-x64@npm:0.4.3"
+"impit-darwin-x64@npm:0.4.4":
+  version: 0.4.4
+  resolution: "impit-darwin-x64@npm:0.4.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.4.3":
-  version: 0.4.3
-  resolution: "impit-linux-arm64-gnu@npm:0.4.3"
+"impit-linux-arm64-gnu@npm:0.4.4":
+  version: 0.4.4
+  resolution: "impit-linux-arm64-gnu@npm:0.4.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.4.3":
-  version: 0.4.3
-  resolution: "impit-linux-arm64-musl@npm:0.4.3"
+"impit-linux-arm64-musl@npm:0.4.4":
+  version: 0.4.4
+  resolution: "impit-linux-arm64-musl@npm:0.4.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.4.3":
-  version: 0.4.3
-  resolution: "impit-linux-x64-gnu@npm:0.4.3"
+"impit-linux-x64-gnu@npm:0.4.4":
+  version: 0.4.4
+  resolution: "impit-linux-x64-gnu@npm:0.4.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.4.3":
-  version: 0.4.3
-  resolution: "impit-linux-x64-musl@npm:0.4.3"
+"impit-linux-x64-musl@npm:0.4.4":
+  version: 0.4.4
+  resolution: "impit-linux-x64-musl@npm:0.4.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.4.3":
-  version: 0.4.3
-  resolution: "impit-win32-arm64-msvc@npm:0.4.3"
+"impit-win32-arm64-msvc@npm:0.4.4":
+  version: 0.4.4
+  resolution: "impit-win32-arm64-msvc@npm:0.4.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.4.3":
-  version: 0.4.3
-  resolution: "impit-win32-x64-msvc@npm:0.4.3"
+"impit-win32-x64-msvc@npm:0.4.4":
+  version: 0.4.4
+  resolution: "impit-win32-x64-msvc@npm:0.4.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2418,14 +2418,14 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^22.13.1"
     express: "npm:^5.0.0"
-    impit-darwin-arm64: "npm:0.4.3"
-    impit-darwin-x64: "npm:0.4.3"
-    impit-linux-arm64-gnu: "npm:0.4.3"
-    impit-linux-arm64-musl: "npm:0.4.3"
-    impit-linux-x64-gnu: "npm:0.4.3"
-    impit-linux-x64-musl: "npm:0.4.3"
-    impit-win32-arm64-msvc: "npm:0.4.3"
-    impit-win32-x64-msvc: "npm:0.4.3"
+    impit-darwin-arm64: "npm:0.4.4"
+    impit-darwin-x64: "npm:0.4.4"
+    impit-linux-arm64-gnu: "npm:0.4.4"
+    impit-linux-arm64-musl: "npm:0.4.4"
+    impit-linux-x64-gnu: "npm:0.4.4"
+    impit-linux-x64-musl: "npm:0.4.4"
+    impit-win32-arm64-msvc: "npm:0.4.4"
+    impit-win32-x64-msvc: "npm:0.4.4"
     vitest: "npm:^3.0.5"
   dependenciesMeta:
     impit-darwin-arm64:


### PR DESCRIPTION
Wraps the original `napi-rs` ENOENT error with a more descriptive error message. Understands `IMPIT_VERBOSE` envvar for printing the original error message.