### PR TITLE
feat: add context manager interface for `Client` and `AsyncClient`

### DIFF
--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -14,6 +14,23 @@ pub(crate) struct AsyncClient {
 
 #[pymethods]
 impl AsyncClient {
+    pub fn __aenter__(
+        slf: Py<Self>,
+        py: Python<'_>,
+    ) -> Result<pyo3::Bound<'_, pyo3::PyAny>, pyo3::PyErr> {
+        pyo3_async_runtimes::async_std::future_into_py::<_, Py<AsyncClient>>(py, async { Ok(slf) })
+    }
+
+    pub fn __aexit__<'python>(
+        &mut self,
+        _exc_type: &crate::Bound<'_, crate::PyAny>,
+        _exc_value: &crate::Bound<'_, crate::PyAny>,
+        _traceback: &crate::Bound<'_, crate::PyAny>,
+        py: Python<'python>,
+    ) -> Result<pyo3::Bound<'python, pyo3::PyAny>, pyo3::PyErr> {
+        pyo3_async_runtimes::async_std::future_into_py::<_, ()>(py, async { Ok(()) })
+    }
+
     #[new]
     #[pyo3(signature = (browser=None, http3=None, proxy=None, timeout=None, verify=None, default_encoding=None, follow_redirects=None, max_redirects=Some(20)))]
     pub fn new(

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -22,6 +22,18 @@ pub(crate) struct Client {
 
 #[pymethods]
 impl Client {
+    pub fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    pub fn __exit__(
+        &mut self,
+        _exc_type: &crate::Bound<'_, crate::PyAny>,
+        _exc_value: &crate::Bound<'_, crate::PyAny>,
+        _traceback: &crate::Bound<'_, crate::PyAny>,
+    ) {
+    }
+
     #[new]
     #[pyo3(signature = (browser=None, http3=None, proxy=None, timeout=None, verify=None, default_encoding=None, follow_redirects=None, max_redirects=Some(20)))]
     pub fn new(

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -28,6 +28,12 @@ class TestBasicRequests:
         assert resp.status_code == 200
 
     @pytest.mark.asyncio
+    async def test_context_manager(self, browser: Browser) -> None:
+        async with AsyncClient(browser=browser) as impit:
+            resp = await impit.get('https://example.org')
+            assert resp.status_code == 200
+
+    @pytest.mark.asyncio
     async def test_boringssl_based_server(self, browser: Browser) -> None:
         impit = AsyncClient(browser=browser)
 

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -26,6 +26,11 @@ class TestBasicRequests:
         resp = impit.get(f'{protocol}example.org')
         assert resp.status_code == 200
 
+    def test_context_manager(self, browser: Browser) -> None:
+        with Client(browser=browser) as impit:
+            resp = impit.get('https://example.org')
+            assert resp.status_code == 200
+
     def test_boringssl_based_server(self, browser: Browser) -> None:
         impit = Client(browser=browser)
 


### PR DESCRIPTION
Enables using `AsyncClient` and `Client` constructors as context managers inside the `with statements`. This allows for use cases like this:

```python
async with AsyncClient() as impit:
    resp = await impit.get('https://example.org')
```

and

```python
with Client() as impit:
    resp = impit.get('https://example.org')
```

which brings `impit` closer to `httpx` interface.

Closes #174 