### PR TITLE
feat: show the underlying `reqwest` error on unrecognized error type

### DIFF
--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{error::Error, time::Duration};
 
 use thiserror::Error;
 
@@ -88,8 +88,8 @@ pub enum ImpitError {
     InvalidHeaderName(String),
     #[error("The header value `{0}` is invalid.")]
     InvalidHeaderValue(String),
-    #[error("{0:#?}")]
-    ReqwestError(reqwest::Error),
+    #[error("The internal HTTP library has thrown an error:\n{0}")]
+    ReqwestError(String),
 }
 
 impl ImpitError {
@@ -102,6 +102,10 @@ impl ImpitError {
             return ImpitError::TooManyRedirects(context.max_redirects);
         }
 
-        ImpitError::RequestError
+        if let Some(source) = error.source() {
+            return ImpitError::ReqwestError(format!("{:#?}", source));
+        }
+
+        ImpitError::ReqwestError(format!("{:#?}", error))
     }
 }

--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, time::Duration};
+use std::time::Duration;
 
 use thiserror::Error;
 
@@ -100,10 +100,6 @@ impl ImpitError {
 
         if error.is_redirect() {
             return ImpitError::TooManyRedirects(context.max_redirects);
-        }
-
-        if let Some(source) = error.source() {
-            return ImpitError::ReqwestError(format!("{:#?}", source));
         }
 
         ImpitError::ReqwestError(format!("{:#?}", error))


### PR DESCRIPTION
Improve error logs in bindings by tunneling the lower-level `reqwest` errors through to binding users. 