### PR TITLE
feat(js): add `resp.arrayBuffer`, improve Node <22 compatibility

### DIFF
--- a/impit-node/Cargo.toml
+++ b/impit-node/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "3.0.0-alpha.27", default-features = false, features = ["napi4", "async", "web_stream", "tokio_rt"] }
+napi = { version = "3.0.0-alpha.27", default-features = false, features = ["napi4", "napi5", "async", "web_stream", "tokio_rt"] }
 napi-derive = "3.0.0-alpha.25"
 impit = { path="../impit" }
 rustls = { version="0.23.16" }

--- a/impit-node/index.d.ts
+++ b/impit-node/index.d.ts
@@ -14,6 +14,7 @@ export declare class ImpitResponse {
   ok: boolean
   url: string
   decodeBuffer(buffer: Buffer): string
+  arrayBuffer(this: object): Promise<ArrayBuffer>
   bytes(this: object): Promise<Uint8Array>
   text(this: object): Promise<string>
   json(this: object): Promise<any>

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -47,13 +47,13 @@
   "packageManager": "yarn@4.9.1",
   "description": "Impit for JavaScript",
   "optionalDependencies": {
-    "impit-darwin-x64": "0.4.6",
     "impit-darwin-arm64": "0.4.6",
-    "impit-win32-x64-msvc": "0.4.6",
-    "impit-win32-arm64-msvc": "0.4.6",
+    "impit-darwin-x64": "0.4.6",
+    "impit-linux-arm64-gnu": "0.4.6",
+    "impit-linux-arm64-musl": "0.4.6",
     "impit-linux-x64-gnu": "0.4.6",
     "impit-linux-x64-musl": "0.4.6",
-    "impit-linux-arm64-gnu": "0.4.6",
-    "impit-linux-arm64-musl": "0.4.6"
+    "impit-win32-arm64-msvc": "0.4.6",
+    "impit-win32-x64-msvc": "0.4.6"
   }
 }

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -213,11 +213,19 @@ describe.each([
         });
 
         test('.bytes() method works', async (t) => {
-        const response = await impit.fetch(getHttpBinUrl('/xml'));
-        const bytes = await response.bytes();
+            const response = await impit.fetch(getHttpBinUrl('/xml'));
+            const bytes = await response.bytes();
 
-        // test that first 5 bytes of the response are the `<?xml` XML declaration
-        t.expect(bytes.slice(0, 5)).toEqual(Uint8Array.from([0x3c, 0x3f, 0x78, 0x6d, 0x6c]));
+            // test that first 5 bytes of the response are the `<?xml` XML declaration
+            t.expect(bytes.slice(0, 5)).toEqual(Uint8Array.from([0x3c, 0x3f, 0x78, 0x6d, 0x6c]));
+        });
+        
+        test('.arrayBuffer() method works', async (t) => {
+            const response = await impit.fetch(getHttpBinUrl('/xml'));
+            const bytes = await response.arrayBuffer();
+
+            // test that first 5 bytes of the response are the `<?xml` XML declaration
+            t.expect(new Uint8Array(bytes.slice(0, 5))).toEqual(Uint8Array.from([0x3c, 0x3f, 0x78, 0x6d, 0x6c]));
         });
 
         test('streaming response body works', async (t) => {

--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -2354,58 +2354,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.4.5":
-  version: 0.4.5
-  resolution: "impit-darwin-arm64@npm:0.4.5"
+"impit-darwin-arm64@npm:0.4.6":
+  version: 0.4.6
+  resolution: "impit-darwin-arm64@npm:0.4.6"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.4.5":
-  version: 0.4.5
-  resolution: "impit-darwin-x64@npm:0.4.5"
+"impit-darwin-x64@npm:0.4.6":
+  version: 0.4.6
+  resolution: "impit-darwin-x64@npm:0.4.6"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.4.5":
-  version: 0.4.5
-  resolution: "impit-linux-arm64-gnu@npm:0.4.5"
+"impit-linux-arm64-gnu@npm:0.4.6":
+  version: 0.4.6
+  resolution: "impit-linux-arm64-gnu@npm:0.4.6"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.4.5":
-  version: 0.4.5
-  resolution: "impit-linux-arm64-musl@npm:0.4.5"
+"impit-linux-arm64-musl@npm:0.4.6":
+  version: 0.4.6
+  resolution: "impit-linux-arm64-musl@npm:0.4.6"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.4.5":
-  version: 0.4.5
-  resolution: "impit-linux-x64-gnu@npm:0.4.5"
+"impit-linux-x64-gnu@npm:0.4.6":
+  version: 0.4.6
+  resolution: "impit-linux-x64-gnu@npm:0.4.6"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.4.5":
-  version: 0.4.5
-  resolution: "impit-linux-x64-musl@npm:0.4.5"
+"impit-linux-x64-musl@npm:0.4.6":
+  version: 0.4.6
+  resolution: "impit-linux-x64-musl@npm:0.4.6"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.4.5":
-  version: 0.4.5
-  resolution: "impit-win32-arm64-msvc@npm:0.4.5"
+"impit-win32-arm64-msvc@npm:0.4.6":
+  version: 0.4.6
+  resolution: "impit-win32-arm64-msvc@npm:0.4.6"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.4.5":
-  version: 0.4.5
-  resolution: "impit-win32-x64-msvc@npm:0.4.5"
+"impit-win32-x64-msvc@npm:0.4.6":
+  version: 0.4.6
+  resolution: "impit-win32-x64-msvc@npm:0.4.6"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2418,14 +2418,14 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^22.13.1"
     express: "npm:^5.0.0"
-    impit-darwin-arm64: "npm:0.4.5"
-    impit-darwin-x64: "npm:0.4.5"
-    impit-linux-arm64-gnu: "npm:0.4.5"
-    impit-linux-arm64-musl: "npm:0.4.5"
-    impit-linux-x64-gnu: "npm:0.4.5"
-    impit-linux-x64-musl: "npm:0.4.5"
-    impit-win32-arm64-msvc: "npm:0.4.5"
-    impit-win32-x64-msvc: "npm:0.4.5"
+    impit-darwin-arm64: "npm:0.4.6"
+    impit-darwin-x64: "npm:0.4.6"
+    impit-linux-arm64-gnu: "npm:0.4.6"
+    impit-linux-arm64-musl: "npm:0.4.6"
+    impit-linux-x64-gnu: "npm:0.4.6"
+    impit-linux-x64-musl: "npm:0.4.6"
+    impit-win32-arm64-msvc: "npm:0.4.6"
+    impit-win32-x64-msvc: "npm:0.4.6"
     vitest: "npm:^3.0.5"
   dependenciesMeta:
     impit-darwin-arm64:


### PR DESCRIPTION
Adds new `response.arrayBuffer` method ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Response/arrayBuffer)) and implements `response.bytes` using `arrayBuffer()` to improve compatibility with Node < 22 (`.bytes()` support was rather experimental until this version).