### PR TITLE
fix(js): support `null` request payload, don't modify options

### DIFF
--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -54,6 +54,8 @@ class Impit extends native.Impit {
                 options.headers = options.headers || [];
                 options.headers.push(['Content-Type', type]);
             }
+        } else {
+            delete options.body;
         }
         
         const originalResponse = await super.fetch(url, options);

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -25,27 +25,27 @@ class ResponsePatches {
 }
 
 class Impit extends native.Impit {
-    async fetch(url, options) {
-        let headers;
+    async fetch(url, opts) {
+        let options = { ...opts };
+
         if (options?.headers) {
             if (options.headers instanceof Headers) {
-                headers = [...options.headers.entries()];
+                options.headers = [...options.headers.entries()];
             } else if (!Array.isArray(options.headers)) {
-                headers = Object.entries(options.headers || {});
+                options.headers = Object.entries(options.headers || {});
             }
         }
 
-        let body;
         if (options?.body) {
             const { body: requestBody, type } = await castToTypedArray(options.body);
-            body = requestBody;
+            options.body = requestBody;
             if (type) {
-                headers = options.headers || [];
-                headers.push(['Content-Type', type]);
+                options.headers = options.headers || [];
+                options.headers.push(['Content-Type', type]);
             }
         }
         
-        const originalResponse = await super.fetch(url, { ...options, headers, body });
+        const originalResponse = await super.fetch(url, options);
 
         Object.defineProperty(originalResponse, 'text', {
             value: ResponsePatches.text.bind(originalResponse)

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -26,24 +26,26 @@ class ResponsePatches {
 
 class Impit extends native.Impit {
     async fetch(url, options) {
+        let headers;
         if (options?.headers) {
             if (options.headers instanceof Headers) {
-                options.headers = [...options.headers.entries()];
+                headers = [...options.headers.entries()];
             } else if (!Array.isArray(options.headers)) {
-                options.headers = Object.entries(options.headers || {});
+                headers = Object.entries(options.headers || {});
             }
         }
 
+        let body;
         if (options?.body) {
-            const { body, type } = await castToTypedArray(options.body);
-            options.body = body;
+            const { body: requestBody, type } = await castToTypedArray(options.body);
+            body = requestBody;
             if (type) {
-                options.headers = options.headers || [];
-                options.headers.push(['Content-Type', type]);
+                headers = options.headers || [];
+                headers.push(['Content-Type', type]);
             }
         }
         
-        const originalResponse = await super.fetch(url, options);
+        const originalResponse = await super.fetch(url, { ...options, headers, body });
 
         Object.defineProperty(originalResponse, 'text', {
             value: ResponsePatches.text.bind(originalResponse)

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -47,13 +47,13 @@
   "packageManager": "yarn@4.9.1",
   "description": "Impit for JavaScript",
   "optionalDependencies": {
-    "impit-darwin-x64": "0.4.7",
     "impit-darwin-arm64": "0.4.7",
-    "impit-win32-x64-msvc": "0.4.7",
-    "impit-win32-arm64-msvc": "0.4.7",
+    "impit-darwin-x64": "0.4.7",
+    "impit-linux-arm64-gnu": "0.4.7",
+    "impit-linux-arm64-musl": "0.4.7",
     "impit-linux-x64-gnu": "0.4.7",
     "impit-linux-x64-musl": "0.4.7",
-    "impit-linux-arm64-gnu": "0.4.7",
-    "impit-linux-arm64-musl": "0.4.7"
+    "impit-win32-arm64-msvc": "0.4.7",
+    "impit-win32-x64-msvc": "0.4.7"
   }
 }

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -170,12 +170,16 @@ describe.each([
             ['URLSearchParams', new URLSearchParams(JSON.parse(STRING_PAYLOAD))],
             ['FormData', (() => { const form = new FormData(); form.append('Impit-Test', 'foořžš'); return form; })()],
             ['ReadableStream', new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode(STRING_PAYLOAD)); controller.close(); } })],
+            ['undefined', undefined],
+            ['null', null],
         ])('passing %s body', async (type, body) => {
             const response = await impit.fetch(getHttpBinUrl('/post'), { method: HttpMethod.Post, body });
             const json = await response.json();
 
             if (type === 'URLSearchParams' || type === 'FormData') {
                 expect(json.form).toEqual(JSON.parse(STRING_PAYLOAD));
+            } else if (type === 'undefined' || type === 'null') {
+                expect(json.data).toEqual('');
             } else {
                 expect(json.data).toEqual(STRING_PAYLOAD);
             }

--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -2354,58 +2354,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.4.6":
-  version: 0.4.6
-  resolution: "impit-darwin-arm64@npm:0.4.6"
+"impit-darwin-arm64@npm:0.4.7":
+  version: 0.4.7
+  resolution: "impit-darwin-arm64@npm:0.4.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.4.6":
-  version: 0.4.6
-  resolution: "impit-darwin-x64@npm:0.4.6"
+"impit-darwin-x64@npm:0.4.7":
+  version: 0.4.7
+  resolution: "impit-darwin-x64@npm:0.4.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.4.6":
-  version: 0.4.6
-  resolution: "impit-linux-arm64-gnu@npm:0.4.6"
+"impit-linux-arm64-gnu@npm:0.4.7":
+  version: 0.4.7
+  resolution: "impit-linux-arm64-gnu@npm:0.4.7"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.4.6":
-  version: 0.4.6
-  resolution: "impit-linux-arm64-musl@npm:0.4.6"
+"impit-linux-arm64-musl@npm:0.4.7":
+  version: 0.4.7
+  resolution: "impit-linux-arm64-musl@npm:0.4.7"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.4.6":
-  version: 0.4.6
-  resolution: "impit-linux-x64-gnu@npm:0.4.6"
+"impit-linux-x64-gnu@npm:0.4.7":
+  version: 0.4.7
+  resolution: "impit-linux-x64-gnu@npm:0.4.7"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.4.6":
-  version: 0.4.6
-  resolution: "impit-linux-x64-musl@npm:0.4.6"
+"impit-linux-x64-musl@npm:0.4.7":
+  version: 0.4.7
+  resolution: "impit-linux-x64-musl@npm:0.4.7"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.4.6":
-  version: 0.4.6
-  resolution: "impit-win32-arm64-msvc@npm:0.4.6"
+"impit-win32-arm64-msvc@npm:0.4.7":
+  version: 0.4.7
+  resolution: "impit-win32-arm64-msvc@npm:0.4.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.4.6":
-  version: 0.4.6
-  resolution: "impit-win32-x64-msvc@npm:0.4.6"
+"impit-win32-x64-msvc@npm:0.4.7":
+  version: 0.4.7
+  resolution: "impit-win32-x64-msvc@npm:0.4.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2418,14 +2418,14 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^22.13.1"
     express: "npm:^5.0.0"
-    impit-darwin-arm64: "npm:0.4.6"
-    impit-darwin-x64: "npm:0.4.6"
-    impit-linux-arm64-gnu: "npm:0.4.6"
-    impit-linux-arm64-musl: "npm:0.4.6"
-    impit-linux-x64-gnu: "npm:0.4.6"
-    impit-linux-x64-musl: "npm:0.4.6"
-    impit-win32-arm64-msvc: "npm:0.4.6"
-    impit-win32-x64-msvc: "npm:0.4.6"
+    impit-darwin-arm64: "npm:0.4.7"
+    impit-darwin-x64: "npm:0.4.7"
+    impit-linux-arm64-gnu: "npm:0.4.7"
+    impit-linux-arm64-musl: "npm:0.4.7"
+    impit-linux-x64-gnu: "npm:0.4.7"
+    impit-linux-x64-musl: "npm:0.4.7"
+    impit-win32-arm64-msvc: "npm:0.4.7"
+    impit-win32-x64-msvc: "npm:0.4.7"
     vitest: "npm:^3.0.5"
   dependenciesMeta:
     impit-darwin-arm64:


### PR DESCRIPTION
Removes parameter reassignment code smell. Fixes errors on `null` (or other nullish, but not expected) body.