### PR TITLE
fix(js): solve memory leak on response read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.0.0-alpha.33"
+version = "3.0.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c857a2b38c994db8bec785554ab4216d45ad63469832070c86a992be0b5491ad"
+checksum = "2a5c343e6e1fb57bf3ea3386638c4affb394ee932708128840a56aaac3d6a8ab"
 dependencies = [
  "bitflags",
  "ctor",
@@ -1771,11 +1771,12 @@ checksum = "e28acfa557c083f6e254a786e01ba253fc56f18ee000afcd4f79af735f73a6da"
 
 [[package]]
 name = "napi-derive"
-version = "3.0.0-alpha.29"
+version = "3.0.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7165d931d54f68115e651330d5fe0ae0081133d3f4ee3ab55b0b808f0c23f71"
+checksum = "08d23065ee795a4b1a8755fdf4a39c2a229679f01f923a8feea33f045d6d96cb"
 dependencies = [
  "convert_case",
+ "ctor",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -1784,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "2.0.0-alpha.28"
+version = "2.0.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3f36354262054df8e1c3a73bdcd36ea13f130feb1e4d86b67cab9e10d6ef6d"
+checksum = "348aaac2c51b5d11cf90cf7670b470c7f4d1607d15c338efd4d3db361003e4f5"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1797,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc061b99c514ad4b7abc99d4db1ca24b9542b7ff48b4760bd9f82b24611534d"
+checksum = "b443b980b2258dbaa31b99115e74da6c0866e537278309d566b4672a2f8df516"
 dependencies = [
  "libloading",
 ]

--- a/impit-node/Cargo.toml
+++ b/impit-node/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.0.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "3.0.0-alpha.27", default-features = false, features = ["napi4", "napi5", "async", "web_stream", "tokio_rt"] }
-napi-derive = "3.0.0-alpha.25"
+napi = { version = "3.0.0-beta.3", default-features = false, features = ["napi4", "napi5", "async", "web_stream", "tokio_rt"] }
+napi-derive = "3.0.0-beta.3"
 impit = { path="../impit" }
 rustls = { version="0.23.16" }
 tokio = { version="1.41.1", features = ["full"] }

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -48,13 +48,13 @@
   "packageManager": "yarn@4.9.1",
   "description": "Impit for JavaScript",
   "optionalDependencies": {
-    "impit-darwin-x64": "0.5.0",
     "impit-darwin-arm64": "0.5.0",
-    "impit-win32-x64-msvc": "0.5.0",
-    "impit-win32-arm64-msvc": "0.5.0",
+    "impit-darwin-x64": "0.5.0",
+    "impit-linux-arm64-gnu": "0.5.0",
+    "impit-linux-arm64-musl": "0.5.0",
     "impit-linux-x64-gnu": "0.5.0",
     "impit-linux-x64-musl": "0.5.0",
-    "impit-linux-arm64-gnu": "0.5.0",
-    "impit-linux-arm64-musl": "0.5.0"
+    "impit-win32-arm64-msvc": "0.5.0",
+    "impit-win32-x64-msvc": "0.5.0"
   }
 }

--- a/impit-node/src/impit_builder.rs
+++ b/impit-node/src/impit_builder.rs
@@ -4,7 +4,7 @@ use impit::{
   emulation::Browser as ImpitBrowser,
   impit::{ImpitBuilder, RedirectBehavior},
 };
-use napi::Env;
+use napi::{bindgen_prelude::Object, Env};
 use napi_derive::napi;
 
 use crate::request::NodeCookieJar;
@@ -26,7 +26,7 @@ impl From<Browser> for ImpitBrowser {
 
 #[derive(Default)]
 #[napi(object)]
-pub struct ImpitOptions {
+pub struct ImpitOptions<'a> {
   pub browser: Option<Browser>,
   pub ignore_tls_errors: Option<bool>,
   pub vanilla_fallback: Option<bool>,
@@ -45,10 +45,10 @@ pub struct ImpitOptions {
   #[napi(
     ts_type = "{ setCookie: (cookie: string, url: string, cb?: any) => Promise<void> | void, getCookieString: (url: string) => Promise<string> | string }"
   )]
-  pub cookie_jar: Option<napi::JsObject>,
+  pub cookie_jar: Option<Object<'a>>,
 }
 
-impl ImpitOptions {
+impl ImpitOptions<'_> {
   pub fn into_builder(self, env: &Env) -> Result<ImpitBuilder<NodeCookieJar>, napi::Error> {
     let mut config = ImpitBuilder::default();
     if let Some(browser) = self.browser {

--- a/impit-node/src/request.rs
+++ b/impit-node/src/request.rs
@@ -4,10 +4,13 @@ use std::{
 };
 
 use napi::{
-  bindgen_prelude::{FromNapiValue, Function, JsValuesTupleIntoVec, Promise, Uint8Array},
+  bindgen_prelude::{
+    FromNapiValue, Function, JsObjectValue, JsValuesTupleIntoVec, Object, Promise, Uint8Array,
+  },
   threadsafe_function::ThreadsafeFunction,
   Env,
 };
+
 use napi_derive::napi;
 use reqwest::{cookie::CookieStore, header::HeaderValue, Url};
 use tokio::sync::oneshot;
@@ -128,7 +131,7 @@ impl CookieStore for NodeCookieJar {
 }
 
 impl NodeCookieJar {
-  pub fn new(env: &Env, tough_cookie: napi::JsObject) -> Result<Self, napi::Error> {
+  pub fn new(env: &Env, tough_cookie: Object) -> Result<Self, napi::Error> {
     let set_cookie_js_method = match tough_cookie
       .get_named_property::<Function<'_, (String, String), Promise<()>>>("setCookie")
     {

--- a/impit-node/src/response.rs
+++ b/impit-node/src/response.rs
@@ -1,8 +1,11 @@
 #![allow(clippy::await_holding_refcell_ref, deprecated)]
 use impit::utils::{decode, ContentType};
+use napi::bindgen_prelude::JsObjectValue;
 use napi::{
-  bindgen_prelude::{Buffer, FromNapiValue, Function, ReadableStream, Result, This, ToNapiValue},
-  sys, Env, JsFunction, JsObject, JsUnknown,
+  bindgen_prelude::{
+    Buffer, FromNapiValue, Function, Object, ReadableStream, Result, This, ToNapiValue,
+  },
+  sys, Env, JsValue, Unknown,
 };
 use napi_derive::napi;
 use reqwest::Response;
@@ -77,8 +80,8 @@ impl ImpitResponse {
     }
   }
 
-  fn get_inner_response(&self, env: &Env, mut this: This<JsObject>) -> Result<napi::JsObject> {
-    let cached_response = this.get::<JsObject>(INNER_RESPONSE_PROPERTY_NAME)?;
+  fn get_inner_response(&self, env: &Env, mut this: This<Object>) -> Result<Object> {
+    let cached_response = this.get::<Object>(INNER_RESPONSE_PROPERTY_NAME)?;
 
     if cached_response.is_none() {
       let mut response = self.inner.borrow_mut();
@@ -107,12 +110,12 @@ impl ImpitResponse {
 
       let response_constructor = env
         .get_global()
-        .and_then(|global| global.get_named_property::<JsFunction>("Response"))
+        .and_then(|global| global.get_named_property::<Function>("Response"))
         .expect("fatal: Couldn't get Response constructor");
 
       this.set(
         INNER_RESPONSE_PROPERTY_NAME,
-        response_constructor.new_instance(&[js_stream])?,
+        response_constructor.new_instance(js_stream.to_unknown())?,
       )?;
     }
 
@@ -137,49 +140,45 @@ impl ImpitResponse {
   }
 
   #[napi(ts_return_type = "Promise<ArrayBuffer>")]
-  pub fn array_buffer(&self, env: &Env, this: This<JsObject>) -> Result<JsObject> {
+  pub fn array_buffer(&self, env: &Env, this: This<Object>) -> Result<Object> {
     let response = self.get_inner_response(env, this)?;
 
     response
-      .get_named_property::<JsFunction>("arrayBuffer")?
-      .call_without_args(Some(&response))?
+      .get_named_property::<Function<'_, (), Object>>("arrayBuffer")?
+      .apply(Some(&response), ())?
       .coerce_to_object()
   }
 
   #[napi(ts_return_type = "Promise<Uint8Array>")]
-  pub fn bytes(&self, env: &Env, this: This<JsObject>) -> Result<JsUnknown> {
+  pub fn bytes(&self, env: &Env, this: This<Object>) -> Result<Object> {
     let array_buffer_promise = self.array_buffer(env, this)?;
-    let then: JsFunction = array_buffer_promise.get_named_property("then")?;
+    let then: Function<'_, Function<Object, Unknown>, Object> =
+      array_buffer_promise.get_named_property("then")?;
 
-    let cb: Function<'_, JsObject, _> = env.create_function_from_closure("callback", |ctx| {
-      let result = ctx.get::<JsObject>(0)?;
+    let cb = env
+      .get_global()?
+      .get_named_property::<Function<'_, String, Function<Object, Unknown>>>("eval")?
+      .call("(buf) => new Uint8Array(buf)".to_string())?;
 
-      ctx
-        .env
-        .get_global()?
-        .get_named_property::<JsFunction>("Uint8Array")?
-        .new_instance(&[result])
-    })?;
-
-    then.call(Some(&array_buffer_promise), &[cb])
+    then.apply(Some(&array_buffer_promise), cb)
   }
 
   #[napi(ts_return_type = "Promise<string>")]
-  pub fn text(&self, env: &Env, this: This<JsObject>) -> Result<JsUnknown> {
+  pub fn text(&self, env: &Env, this: This<Object>) -> Result<Unknown> {
     let response = self.get_inner_response(env, this)?;
 
     response
-      .get_named_property::<JsFunction>("text")?
-      .call_without_args(Some(&response))
+      .get_named_property::<Function<'_, (), Unknown>>("text")?
+      .apply(response, ())
   }
 
   #[napi(ts_return_type = "Promise<any>")]
-  pub fn json(&self, env: &Env, this: This<JsObject>) -> Result<JsUnknown> {
+  pub fn json(&self, env: &Env, this: This<Object>) -> Result<Unknown> {
     let response = self.get_inner_response(env, this)?;
 
     response
-      .get_named_property::<JsFunction>("json")?
-      .call_without_args(Some(&response))
+      .get_named_property::<Function<'_, (), Unknown>>("json")?
+      .apply(response, ())
   }
 
   #[napi(
@@ -187,7 +186,7 @@ impl ImpitResponse {
     js_name = "body",
     ts_return_type = "ReadableStream<Uint8Array>"
   )]
-  pub fn body(&self, env: &Env, this: This<JsObject>) -> Result<napi::JsObject> {
+  pub fn body(&self, env: &Env, this: This<Object>) -> Result<Object> {
     let response = self.get_inner_response(env, this)?;
 
     response.get_named_property("body")

--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -2338,58 +2338,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.4.7":
-  version: 0.4.7
-  resolution: "impit-darwin-arm64@npm:0.4.7"
+"impit-darwin-arm64@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-darwin-arm64@npm:0.5.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.4.7":
-  version: 0.4.7
-  resolution: "impit-darwin-x64@npm:0.4.7"
+"impit-darwin-x64@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-darwin-x64@npm:0.5.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.4.7":
-  version: 0.4.7
-  resolution: "impit-linux-arm64-gnu@npm:0.4.7"
+"impit-linux-arm64-gnu@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-linux-arm64-gnu@npm:0.5.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.4.7":
-  version: 0.4.7
-  resolution: "impit-linux-arm64-musl@npm:0.4.7"
+"impit-linux-arm64-musl@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-linux-arm64-musl@npm:0.5.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.4.7":
-  version: 0.4.7
-  resolution: "impit-linux-x64-gnu@npm:0.4.7"
+"impit-linux-x64-gnu@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-linux-x64-gnu@npm:0.5.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.4.7":
-  version: 0.4.7
-  resolution: "impit-linux-x64-musl@npm:0.4.7"
+"impit-linux-x64-musl@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-linux-x64-musl@npm:0.5.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.4.7":
-  version: 0.4.7
-  resolution: "impit-win32-arm64-msvc@npm:0.4.7"
+"impit-win32-arm64-msvc@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-win32-arm64-msvc@npm:0.5.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.4.7":
-  version: 0.4.7
-  resolution: "impit-win32-x64-msvc@npm:0.4.7"
+"impit-win32-x64-msvc@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-win32-x64-msvc@npm:0.5.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2402,14 +2402,14 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^22.13.1"
     express: "npm:^5.0.0"
-    impit-darwin-arm64: "npm:0.4.7"
-    impit-darwin-x64: "npm:0.4.7"
-    impit-linux-arm64-gnu: "npm:0.4.7"
-    impit-linux-arm64-musl: "npm:0.4.7"
-    impit-linux-x64-gnu: "npm:0.4.7"
-    impit-linux-x64-musl: "npm:0.4.7"
-    impit-win32-arm64-msvc: "npm:0.4.7"
-    impit-win32-x64-msvc: "npm:0.4.7"
+    impit-darwin-arm64: "npm:0.5.0"
+    impit-darwin-x64: "npm:0.5.0"
+    impit-linux-arm64-gnu: "npm:0.5.0"
+    impit-linux-arm64-musl: "npm:0.5.0"
+    impit-linux-x64-gnu: "npm:0.5.0"
+    impit-linux-x64-musl: "npm:0.5.0"
+    impit-win32-arm64-msvc: "npm:0.5.0"
+    impit-win32-x64-msvc: "npm:0.5.0"
     tough-cookie: "npm:^5.1.2"
     vitest: "npm:^3.0.5"
   dependenciesMeta:


### PR DESCRIPTION
Memory leak in `napi-rs`'s implementation of `ReadableStream` was causing `impit` to leak small amounts of memory on response read (`.text()`, `.json()`, `.bytes()` etc.).

This PR bumps the `napi-rs` version to the latest beta, where the memory leak cause is fixed.