### PR TITLE
feat: client-scoped `headers` option

### DIFF
--- a/impit-node/src/impit_builder.rs
+++ b/impit-node/src/impit_builder.rs
@@ -46,6 +46,8 @@ pub struct ImpitOptions<'a> {
     ts_type = "{ setCookie: (cookie: string, url: string, cb?: any) => Promise<void> | void, getCookieString: (url: string) => Promise<string> | string }"
   )]
   pub cookie_jar: Option<Object<'a>>,
+  /// Additional headers to include in every request made by this Impit instance.
+  pub headers: Option<Vec<(String, String)>>,
 }
 
 impl ImpitOptions<'_> {
@@ -78,6 +80,9 @@ impl ImpitOptions<'_> {
         }
         Err(e) => return Err(e),
       }
+    }
+    if let Some(headers) = self.headers {
+      config = config.with_headers(headers);
     }
 
     let follow_redirects: bool = self.follow_redirects.unwrap_or(true);

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -77,7 +77,7 @@ describe.each([
             const response = impit.fetch(`${protocol}example.org`);
             await expect(response).resolves.toBeTruthy();
         });
-        
+
         test('to a BoringSSL-based server', async () => {
             const response = impit.fetch('https://www.google.com');
             await expect(response).resolves.toBeTruthy();
@@ -123,7 +123,7 @@ describe.each([
             );
 
             t.expect(headers.getSetCookie())
-                .toEqual([ 
+                .toEqual([
                     'a=1; Path=/',
                     'b=2; Path=/',
                     'c=3; Path=/'
@@ -151,9 +151,9 @@ describe.each([
             const cookieJar = new CookieJar();
             cookieJar.setCookieSync('preset-cookie=123; Path=/', getHttpBinUrl('/cookies/'));
 
-            const impit = new Impit({ 
+            const impit = new Impit({
                 cookieJar,
-                browser, 
+                browser,
             })
 
             const response1 = await impit.fetch(
@@ -192,6 +192,25 @@ describe.each([
             const json = await response.json();
 
             t.expect(json.headers?.['User-Agent']).toBe('this is impit!');
+        })
+
+        test('client-scoped headers work', async (t) => {
+            const impit = new Impit({
+                browser,
+                headers: {
+                    'User-Agent': 'client-scoped user agent',
+                }
+            });
+
+            const response = await impit.fetch(getHttpBinUrl('/headers'));
+            const json = await response.json();
+
+            t.expect(json.headers?.['User-Agent']).toBe('client-scoped user agent');
+
+            const response2 = await impit.fetch(getHttpBinUrl('/headers'), { headers: { 'User-Agent': 'overwritten user agent' } });
+            const json2 = await response2.json();
+
+            t.expect(json2.headers?.['User-Agent']).toBe('overwritten user agent');
         })
 
         test('http3 works', async (t) => {
@@ -295,7 +314,7 @@ describe.each([
             // test that first 5 bytes of the response are the `<?xml` XML declaration
             t.expect(bytes.slice(0, 5)).toEqual(Uint8Array.from([0x3c, 0x3f, 0x78, 0x6d, 0x6c]));
         });
-        
+
         test('.arrayBuffer() method works', async (t) => {
             const response = await impit.fetch(getHttpBinUrl('/xml'));
             const bytes = await response.arrayBuffer();

--- a/impit/src/http_headers/mod.rs
+++ b/impit/src/http_headers/mod.rs
@@ -103,9 +103,23 @@ impl HttpHeadersBuilder {
         self
     }
 
-    pub fn with_custom_headers(&mut self, custom_headers: &Vec<(String, String)>) -> &mut Self {
-        self.custom_headers = custom_headers.to_owned();
-        self
+    pub fn with_custom_headers(
+        &mut self,
+        custom_headers: Option<Vec<(String, String)>>,
+    ) -> &mut Self {
+        match custom_headers {
+            Some(headers) => {
+                // Later call to with_custom_headers will override existing headers.
+                // We need to prepend the new headers to the existing ones.
+                self.custom_headers = headers
+                    .iter()
+                    .chain(self.custom_headers.iter())
+                    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                    .collect();
+                self
+            }
+            None => self,
+        }
     }
 
     pub fn build(&self) -> HttpHeaders {

--- a/impit/src/request.rs
+++ b/impit/src/request.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 /// Used by the [`Impit`](crate::impit::Impit) struct's methods.
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {
-    /// A `Vec` of string pairs that represent custom HTTP request headers. These are added to the default headers.
+    /// A `Vec` of string pairs that represent custom HTTP request headers. These take precedence over the headers set in [`ImpitBuilder`](crate::impit::ImpitBuilder)
+    /// (both from the `with_headers` and the `with_browser` methods).
     pub headers: Vec<(String, String)>,
     /// The timeout for the request. This option overrides the global [`Impit`] timeout.
     pub timeout: Option<Duration>,


### PR DESCRIPTION
Adds `headers` setting to `Impit` constructor to set headers to be included in every request made by the built [`Impit`] instance.

This can be used to add e.g. custom user-agent or authorization headers that should be included in every request. These headers override the "impersonation" headers set by the `with_browser` method. In turn, these are overridden by request-specific `headers` setting.

closes #199 