### PR TITLE
chore: update the use of `format!` to match the new clippy checks

### DIFF
--- a/impit-node/src/lib.rs
+++ b/impit-node/src/lib.rs
@@ -99,7 +99,7 @@ impl ImpitWrapper {
           _ => napi::Status::GenericFailure,
         };
 
-        let reason = format!("impit error: {}", err);
+        let reason = format!("impit error: {err}");
 
         Err(napi::Error::new(status, reason))
       }

--- a/impit-node/src/request.rs
+++ b/impit-node/src/request.rs
@@ -66,10 +66,7 @@ fn await_promise<
       Err(e) => {
         let _ = tx.send(Err(napi::Error::new(
           napi::Status::GenericFailure,
-          format!(
-            "[impit] failed to retrieve cookies from the external cookie store: {}",
-            e
-          ),
+          format!("[impit] failed to retrieve cookies from the external cookie store: {e}"),
         )));
       }
     });
@@ -139,10 +136,7 @@ impl NodeCookieJar {
       Err(e) => {
         return Err(napi::Error::new(
           napi::Status::GenericFailure,
-          format!(
-            "[impit] Couldn't find `setCookie` method on the external cookie store: {}",
-            e
-          ),
+          format!("[impit] Couldn't find `setCookie` method on the external cookie store: {e}"),
         ));
       }
     };
@@ -155,8 +149,7 @@ impl NodeCookieJar {
         return Err(napi::Error::new(
           napi::Status::GenericFailure,
           format!(
-            "[impit] Couldn't find `getCookieString` method on the external cookie store: {}",
-            e
+            "[impit] Couldn't find `getCookieString` method on the external cookie store: {e}"
           ),
         ));
       }

--- a/impit-node/src/response.rs
+++ b/impit-node/src/response.rs
@@ -102,7 +102,7 @@ impl ImpitResponse {
         }
         Err(e) => Some(Err(napi::Error::new(
           napi::Status::Unknown,
-          format!("Error reading response stream: {:?}", e),
+          format!("Error reading response stream: {e:?}"),
         ))),
       });
 

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -307,8 +307,7 @@ impl AsyncClient {
                     Ok(form_to_bytes(form))
                 }
                 RequestBody::CatchAll(e) => Err(PyErr::new::<PyTypeError, _>(format!(
-                    "Unsupported data type in request body: {:#?}",
-                    e
+                    "Unsupported data type in request body: {e:#?}"
                 ))),
             },
             None => Ok(Vec::new()),

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -246,7 +246,7 @@ impl Client {
                     Ok(form_to_bytes(form))
                 }
                 RequestBody::CatchAll(e) => Err(ImpitPyError(ImpitError::BindingPassthroughError(
-                    format!("Unsupported data type: {:?}", e).to_string(),
+                    format!("Unsupported data type: {e:?}").to_string(),
                 ))),
             },
             None => Ok(Vec::new()),

--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -102,6 +102,6 @@ impl ImpitError {
             return ImpitError::TooManyRedirects(context.max_redirects);
         }
 
-        ImpitError::ReqwestError(format!("{:#?}", error))
+        ImpitError::ReqwestError(format!("{error:#?}"))
     }
 }

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -328,10 +328,10 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             .build();
 
         let client = if h3 {
-            debug!("Using QUIC for request to {}", url);
+            debug!("Using QUIC for request to {url}");
             self.h3_client.as_ref().unwrap()
         } else {
-            debug!("{} doesn't seem to have HTTP3 support", url);
+            debug!("{url} doesn't seem to have HTTP3 support");
             &self.base_client
         };
 
@@ -383,10 +383,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
                 if let Some(alt_svc) = response.headers().get("Alt-Svc") {
                     let alt_svc = alt_svc.to_str().unwrap();
                     if alt_svc.contains("h3") {
-                        debug!(
-                            "{} supports HTTP/3 (alt-svc header), adding to Alt-Svc cache",
-                            host
-                        );
+                        debug!("{host} supports HTTP/3 (alt-svc header), adding to Alt-Svc cache",);
                         h3_engine.set_h3_support(&host, true);
                     }
                 }


### PR DESCRIPTION
- Updating the use of `format!` to match the new clippy checks