### PR TITLE
chore: fix local usage of `get_httpbin_url` in Python tests

### DIFF
--- a/impit-python/test/httpbin.py
+++ b/impit-python/test/httpbin.py
@@ -13,7 +13,12 @@ def get_httpbin_url(path: str, *, query: dict[str, str] | None = None, https: bo
         url = url._replace(query=urllib.parse.urlencode(query, doseq=True))
     else:
         url = urllib.parse.urlparse('https://httpbin.org')
+        if query:
+            url = url._replace(query=urllib.parse.urlencode(query, doseq=True))
+
     scheme = 'https' if https else 'http'
     url = url._replace(scheme=scheme)
+    result_url = url._replace(path=path).geturl()
+    result_url = result_url.removesuffix('/')
 
-    return url._replace(path=path).geturl()
+    return result_url


### PR DESCRIPTION
Injects correct query params in the httpbin.org URL (when using without `APIFY_HTTPBIN_TOKEN`). Removes trailing slash from the URL to fix 404 errors.