### PR TITLE
fix: Upper case in `browser` field not works

### DIFF
--- a/impit-node/README.md
+++ b/impit-node/README.md
@@ -32,7 +32,7 @@ import { Impit } from 'impit';
 
 // Set up the Impit instance
 const impit = new Impit({
-    browser: "Chrome", // or "Firefox"
+    browser: "chrome", // or "firefox"
     proxyUrl: "http://localhost:8080",
     ignoreTlsErrors: true,
 });


### PR DESCRIPTION
```
#[napi(string_enum = "lowercase")]
pub enum Browser {
  Chrome,
  Firefox,
}
```