### PR TITLE
fix: log correct timeout duration on `TimeoutException`

### DIFF
--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -22,7 +22,7 @@ pub enum ImpitError {
     RequestError,
     #[error("Transport error occurred.")]
     TransportError,
-    #[error("Request timeout ({0}) ms exceeded.")]
+    #[error("Request timeout ({0} ms) exceeded.")]
     TimeoutException(u128),
     #[error("Connection timed out.")]
     ConnectTimeout,

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -372,7 +372,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             return Err(ImpitError::from(
                 response.err().unwrap(),
                 ErrorContext {
-                    timeout: options.timeout.unwrap_or(Duration::from_millis(0)),
+                    timeout: options.timeout.unwrap_or(self.config.request_timeout),
                     max_redirects,
                     method: method.to_string(),
                     protocol: parsed_url.scheme().to_string(),


### PR DESCRIPTION
Logs the default `Impit`-instance-wide timeout if the request-specific timeout is missing.

Closes #221 