### PR TITLE
chore: build for Python < 3.11 on MacOS

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -28,7 +28,7 @@ on:
         type: string
         default: ${{ github.sha }}
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -53,7 +53,7 @@ jobs:
         #     target: aarch64
     steps:
       - uses: actions/checkout@v4
-        with: 
+        with:
           ref: ${{ inputs.commit_sha }}
 
       - name: Install uv
@@ -147,7 +147,7 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
-        with: 
+        with:
           ref: ${{ inputs.commit_sha }}
 
       - uses: actions/setup-python@v5
@@ -219,7 +219,7 @@ jobs:
             target: x64
     steps:
       - uses: actions/checkout@v4
-        with: 
+        with:
           ref: ${{ inputs.commit_sha }}
 
       - name: Install uv
@@ -269,7 +269,7 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
-        with: 
+        with:
           ref: ${{ inputs.commit_sha }}
 
       - name: Install uv
@@ -277,6 +277,9 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          architecture: ${{ matrix.platform.target }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
Installs more Python versions in the MacOS runner for better version coverage with prebuilt binaries on PyPI.