### PR TITLE
fix: Resolve blocking behavior in `impit.Client` during multithreaded operations

### DIFF
--- a/impit-python/src/lib.rs
+++ b/impit-python/src/lib.rs
@@ -84,30 +84,30 @@ fn impit(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("StreamClosed", m.py().get_type::<errors::StreamClosed>())?;
 
     macro_rules! http_no_client {
-        ($($name:ident),*) => {
-            $(
-                #[pyfunction]
-                #[pyo3(signature = (url, content=None, data=None, headers=None, timeout=None, force_http3=false, cookie_jar=None, cookies=None))]
-                fn $name(
-                    _py: Python,
-                    url: String,
-                    content: Option<Vec<u8>>,
-                    data: Option<RequestBody>,
-                    headers: Option<HashMap<String, String>>,
-                    timeout: Option<f64>,
-                    force_http3: Option<bool>,
-                    cookie_jar: Option<pyo3::Bound<'_, pyo3::PyAny>>,
-                    cookies: Option<pyo3::Bound<'_, pyo3::PyAny>>,
-                ) -> Result<response::ImpitPyResponse, errors::ImpitPyError> {
-                    let client = Client::new(_py, None, None, None, None, None, None, None, None, cookie_jar, cookies, None);
+    ($($name:ident),*) => {
+        $(
+            #[pyfunction]
+            #[pyo3(signature = (url, content=None, data=None, headers=None, timeout=None, force_http3=false, cookie_jar=None, cookies=None))]
+            fn $name(
+                _py: Python,
+                url: String,
+                content: Option<Vec<u8>>,
+                data: Option<RequestBody>,
+                headers: Option<HashMap<String, String>>,
+                timeout: Option<f64>,
+                force_http3: Option<bool>,
+                cookie_jar: Option<pyo3::Bound<'_, pyo3::PyAny>>,
+                cookies: Option<pyo3::Bound<'_, pyo3::PyAny>>,
+            ) -> Result<response::ImpitPyResponse, errors::ImpitPyError> {
+                let client = Client::new(_py, None, None, None, None, None, None, None, None, cookie_jar, cookies, None);
 
-                    client.$name(url, content, data, headers, timeout, force_http3)
-                }
+                client.$name(_py, url, content, data, headers, timeout, force_http3)
+            }
 
-                m.add_function(wrap_pyfunction!($name, m)?)?;
-            )*
-        };
-    }
+            m.add_function(wrap_pyfunction!($name, m)?)?;
+        )*
+    };
+}
 
     http_no_client!(get, post, put, head, patch, delete, options, trace);
 

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -1,4 +1,7 @@
+import asyncio
 import json
+import socket
+import threading
 from http.cookiejar import CookieJar
 
 import pytest
@@ -7,6 +10,20 @@ from impit import AsyncClient, Browser, Cookies, StreamClosed, StreamConsumed, T
 
 from .httpbin import get_httpbin_url
 
+
+def thread_server(port_holder: list[int]) -> None:
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(('localhost', 0))
+    port_holder[0] = server.getsockname()[1]
+    server.listen(1)
+
+    conn, _ = server.accept()
+    conn.recv(1024)
+    response = b'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'
+    conn.send(response)
+    conn.close()
+    server.close()
 
 @pytest.mark.parametrize(
     ('browser'),
@@ -278,6 +295,20 @@ class TestBasicRequests:
 
         with pytest.raises(TooManyRedirects):
             await impit.get(redirect_url)
+
+
+    @pytest.mark.asyncio
+    async def test_async_socket_server(self, browser: Browser) -> None:
+        port_holder = [0]
+        thread = threading.Thread(target=thread_server, args=(port_holder,))
+        thread.start()
+        await asyncio.sleep(0.1)
+
+        impit = AsyncClient(browser=browser)
+
+        response = await impit.get(f'http://127.0.0.1:{port_holder[0]}/', timeout=5)
+        assert response.status_code == 200
+        thread.join()
 
 
 @pytest.mark.parametrize(

--- a/impit-python/test/basic_test.py
+++ b/impit-python/test/basic_test.py
@@ -1,4 +1,7 @@
 import json
+import socket
+import threading
+import time
 from http.cookiejar import CookieJar
 
 import pytest
@@ -6,6 +9,21 @@ import pytest
 from impit import Browser, Client, Cookies, StreamClosed, StreamConsumed, TooManyRedirects
 
 from .httpbin import get_httpbin_url
+
+
+def thread_server(port_holder: list[int]) -> None:
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(('localhost', 0))
+    port_holder[0] = server.getsockname()[1]
+    server.listen(1)
+
+    conn, _ = server.accept()
+    conn.recv(1024)
+    response = b'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'
+    conn.send(response)
+    conn.close()
+    server.close()
 
 
 @pytest.mark.parametrize(
@@ -262,6 +280,19 @@ class TestBasicRequests:
 
         with pytest.raises(TooManyRedirects):
             impit.get(redirect_url)
+
+
+    def test_thread_server(self, browser: Browser) -> None:
+        port_holder = [0]
+        thread = threading.Thread(target=thread_server, args=(port_holder,))
+        thread.start()
+        time.sleep(0.1)
+
+        impit = Client(browser=browser)
+
+        response = impit.get(f'http://127.0.0.1:{port_holder[0]}/', timeout=5)
+        assert response.status_code == 200
+        thread.join()
 
 
 @pytest.mark.parametrize(

--- a/impit-python/uv.lock
+++ b/impit-python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "impit"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Resolve blocking behavior in `impit.Client` during multithreaded operations