### PR TITLE
feat{py): Add constructor for `Response`

### DIFF
--- a/impit-python/python/impit/impit.pyi
+++ b/impit-python/python/impit/impit.pyi
@@ -121,7 +121,6 @@ class RequestNotRead(StreamError):
 class StreamClosed(StreamError):
     """Represents an error when a stream is closed."""
 
-
 class Response:
     """Response object returned by impit requests."""
 
@@ -157,6 +156,24 @@ class Response:
 
     is_stream_consumed: bool
     """Whether the response stream has been consumed or closed"""
+
+    def __init__(
+        self,
+        status_code: int = 200,
+        content: bytes | None = None,
+        headers: dict[str, str] | None = None,
+        url: str | None = None,
+        encoding: str | None = None,
+    ) -> None:
+        """Initialize a Response object.
+
+        Args:
+            status_code: HTTP status code
+            content: Response body as bytes
+            headers: Response headers as a dictionary
+            url: Final URL of the response
+            encoding: Encoding for the response text
+        """
 
     def read(self) -> bytes:
         """Read the response content as bytes."""

--- a/impit-python/test/async_test.py
+++ b/impit-python/test/async_test.py
@@ -6,7 +6,7 @@ from http.cookiejar import CookieJar
 
 import pytest
 
-from impit import AsyncClient, Browser, Cookies, StreamClosed, StreamConsumed, TooManyRedirects
+from impit import AsyncClient, Browser, Cookies, Response, StreamClosed, StreamConsumed, TooManyRedirects
 
 from .httpbin import get_httpbin_url
 
@@ -530,3 +530,70 @@ class TestStreamRequest:
 
         with pytest.raises(StreamClosed):
             _ = response.content
+
+
+class TestResponseObject:
+    async def test_setattr(self) -> None:
+        client = AsyncClient()
+
+        response = await client.get(get_httpbin_url('/'))
+
+        assert response.status_code == 200
+
+        assert getattr(response, 'test', None) is None
+
+        response.test = 'test_value'
+
+        assert getattr(response, 'test', None) == 'test_value'
+
+    def test_response_empty_constructor(self) -> None:
+        # Create a new empty response object
+        response = Response()
+
+        assert response.status_code == 200
+        assert response.content == b''
+        assert response.text == ''
+
+        response.test = 'test_value'
+
+        assert getattr(response, 'test', None) == 'test_value'
+
+    def test_response_constructor_with_status(self) -> None:
+        # Create a new response object with a specific status code
+        response = Response(status_code=404)
+
+        assert response.status_code == 404
+        assert response.content == b''
+        assert response.text == ''
+
+        assert response.reason_phrase == 'Not Found'
+
+    def test_response_constructor_with_content(self) -> None:
+        # Create a new response object with content
+        response = Response(content=b'Test content')
+
+        assert response.status_code == 200
+        assert response.content == b'Test content'
+        assert response.text == 'Test content'
+
+    def test_response_constructor_with_headers(self) -> None:
+        # Create a new response object with headers
+        response = Response(headers={'Content-Type': 'application/json'})
+
+        assert response.status_code == 200
+        assert response.headers['Content-Type'] == 'application/json'
+
+    @pytest.mark.parametrize(
+        ('status_code', 'reason_phrase'),
+        [
+            (200, 'OK'),
+            (404, 'Not Found'),
+            (500, 'Internal Server Error'),
+            (301, 'Unknown'),
+        ],
+    )
+    def test_response_constructor_with_status_reason(self, status_code: int, reason_phrase: str) -> None:
+        response = Response(status_code=status_code)
+
+        assert response.status_code == status_code
+        assert response.reason_phrase == reason_phrase

--- a/impit-python/uv.lock
+++ b/impit-python/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "impit"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Add constructor for `Response`. This can be useful when creating tests and mocks.
- Allow to set custom attributes in `Response`