### PR TITLE
feat: improve error typing for certain HTTP errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,19 +1274,21 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1465,6 +1467,8 @@ dependencies = [
  "encoding",
  "hickory-client",
  "hickory-proto",
+ "hyper",
+ "hyper-util",
  "log",
  "mime",
  "num-bigint",

--- a/impit/Cargo.toml
+++ b/impit/Cargo.toml
@@ -19,4 +19,5 @@ thiserror = "2.0.12"
 tokio = { version="1.40.0", features = ["full"] }
 url = "2.5.2"
 webpki-roots = "0.26.6"
-
+hyper-util = "0.1.16"
+hyper = "1.7.0"


### PR DESCRIPTION
Improves error typing (mostly for Python version) on HTTP (network / server) errors and aligns the behaviour with HTTPX.

Closes #244 