### PR TITLE
chore(py): add `__version__` attribute to `impit` module

### DIFF
--- a/impit-python/python/impit/__init__.py
+++ b/impit-python/python/impit/__init__.py
@@ -1,4 +1,5 @@
 from typing import Literal
+from importlib import metadata
 
 from .cookies import Cookies
 from .impit import (
@@ -42,6 +43,8 @@ from .impit import (
     put,
     trace,
 )
+
+__version__ = metadata.version('impit')
 
 __all__ = [
     'AsyncClient',


### PR DESCRIPTION
Adds the `__version__` attribute containing the current module version to the `impit` module.