### PR TITLE
chore: remove unnecessary `.unwrap()` calls

### DIFF
--- a/impit-node/src/response.rs
+++ b/impit-node/src/response.rs
@@ -119,7 +119,13 @@ impl<'env> ImpitResponse {
       )?;
     }
 
-    Ok(this.get(INNER_RESPONSE_PROPERTY_NAME)?.unwrap())
+    this.get(INNER_RESPONSE_PROPERTY_NAME).transpose()
+      .ok_or_else(|| {
+        napi::Error::new(
+          napi::Status::GenericFailure,
+          "fatal: Couldn't get cached response stream".to_string(),
+        )
+      })?
   }
 
   #[napi(ts_return_type = "string")]

--- a/impit-node/src/response.rs
+++ b/impit-node/src/response.rs
@@ -119,7 +119,9 @@ impl<'env> ImpitResponse {
       )?;
     }
 
-    this.get(INNER_RESPONSE_PROPERTY_NAME).transpose()
+    this
+      .get(INNER_RESPONSE_PROPERTY_NAME)
+      .transpose()
       .ok_or_else(|| {
         napi::Error::new(
           napi::Status::GenericFailure,

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -107,7 +107,7 @@ impl AsyncClient {
                 builder.with_cookie_store(PythonCookieJar::new(py, cookie_jar.into()))
             }
             (None, Some(cookies)) => {
-                builder.with_cookie_store(PythonCookieJar::from_httpx_cookies(py, cookies.into()))
+                builder.with_cookie_store(PythonCookieJar::from_httpx_cookies(py, cookies.into())?)
             }
             (None, None) => builder,
         };

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -10,7 +10,7 @@ use pyo3::{ffi::c_str, prelude::*};
 
 use crate::{
     cookies::PythonCookieJar,
-    errors::{CookieConflict, ImpitPyError},
+    errors::ImpitPyError,
     request::{form_to_bytes, RequestBody},
     response::{self, ImpitPyResponse},
 };
@@ -102,9 +102,10 @@ impl Client {
             (Some(cookie_jar), None) => {
                 builder.with_cookie_store(PythonCookieJar::new(py, cookie_jar.into()))
             }
-            (None, Some(cookies)) => {
-                builder.with_cookie_store(PythonCookieJar::from_httpx_cookies(py, cookies.into()).map_err(|e| ImpitPyError(ImpitError::CookieConflict))?)
-            }
+            (None, Some(cookies)) => builder.with_cookie_store(
+                PythonCookieJar::from_httpx_cookies(py, cookies.into())
+                    .map_err(|_e| ImpitPyError(ImpitError::CookieConflict))?,
+            ),
             (None, None) => builder,
         };
 

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -10,7 +10,7 @@ use pyo3::{ffi::c_str, prelude::*};
 
 use crate::{
     cookies::PythonCookieJar,
-    errors::ImpitPyError,
+    errors::{CookieConflict, ImpitPyError},
     request::{form_to_bytes, RequestBody},
     response::{self, ImpitPyResponse},
 };
@@ -103,7 +103,7 @@ impl Client {
                 builder.with_cookie_store(PythonCookieJar::new(py, cookie_jar.into()))
             }
             (None, Some(cookies)) => {
-                builder.with_cookie_store(PythonCookieJar::from_httpx_cookies(py, cookies.into()))
+                builder.with_cookie_store(PythonCookieJar::from_httpx_cookies(py, cookies.into()).map_err(|e| ImpitPyError(ImpitError::CookieConflict))?)
             }
             (None, None) => builder,
         };

--- a/impit-python/src/cookies.rs
+++ b/impit-python/src/cookies.rs
@@ -44,7 +44,9 @@ impl CookieStore for PythonCookieJar {
                     )
                     .unwrap_or_default();
                 kwargs.set_item("comment", None::<&str>).unwrap_or_default();
-                kwargs.set_item("comment_url", None::<&str>).unwrap_or_default();
+                kwargs
+                    .set_item("comment_url", None::<&str>)
+                    .unwrap_or_default();
                 kwargs.set_item("port", None::<&str>).unwrap_or_default();
                 kwargs.set_item("port_specified", false).unwrap_or_default();
                 kwargs
@@ -185,8 +187,8 @@ impl PythonCookieJar {
     }
 
     pub fn from_httpx_cookies(py: Python<'_>, cookies: Py<PyAny>) -> PyResult<Self> {
-        cookies.getattr(py, "jar").and_then(|jar| {
-            Ok(PythonCookieJar::new(py, jar.into()))
-        })
+        cookies
+            .getattr(py, "jar")
+            .map(|jar| PythonCookieJar::new(py, jar))
     }
 }

--- a/impit-python/src/cookies.rs
+++ b/impit-python/src/cookies.rs
@@ -23,18 +23,18 @@ impl CookieStore for PythonCookieJar {
                 let cookie = std::str::from_utf8(header_value.as_bytes())
                     .map_err(cookie::ParseError::from)
                     .and_then(Cookie::parse)
-                    .unwrap();
+                    .unwrap_or(Cookie::new("<cookie-name>", "<cookie-value>"));
 
                 let kwargs = PyDict::new(py);
 
-                kwargs.set_item("name", cookie.name()).unwrap();
-                kwargs.set_item("value", cookie.value()).unwrap();
+                kwargs.set_item("name", cookie.name()).unwrap_or_default();
+                kwargs.set_item("value", cookie.value()).unwrap_or_default();
                 kwargs
                     .set_item("path", cookie.path().unwrap_or(""))
-                    .unwrap();
+                    .unwrap_or_default();
                 kwargs
                     .set_item("secure", cookie.secure().unwrap_or(false))
-                    .unwrap();
+                    .unwrap_or_default();
                 kwargs
                     .set_item(
                         "domain",
@@ -42,40 +42,40 @@ impl CookieStore for PythonCookieJar {
                             .domain()
                             .unwrap_or_else(|| url.host_str().unwrap_or_default()),
                     )
-                    .unwrap();
-                kwargs.set_item("comment", None::<&str>).unwrap();
-                kwargs.set_item("comment_url", None::<&str>).unwrap();
-                kwargs.set_item("port", None::<&str>).unwrap();
-                kwargs.set_item("port_specified", false).unwrap();
+                    .unwrap_or_default();
+                kwargs.set_item("comment", None::<&str>).unwrap_or_default();
+                kwargs.set_item("comment_url", None::<&str>).unwrap_or_default();
+                kwargs.set_item("port", None::<&str>).unwrap_or_default();
+                kwargs.set_item("port_specified", false).unwrap_or_default();
                 kwargs
                     .set_item("path_specified", cookie.path().is_some())
-                    .unwrap();
+                    .unwrap_or_default();
                 kwargs
                     .set_item(
                         "discard",
                         cookie.max_age().is_none() && cookie.expires().is_none(),
                     )
-                    .unwrap();
+                    .unwrap_or_default();
                 kwargs
                     .set_item("domain_specified", cookie.domain().is_some())
-                    .unwrap();
+                    .unwrap_or_default();
                 kwargs
                     .set_item(
                         "domain_initial_dot",
                         cookie.domain().map(|d| d.starts_with('.')),
                     )
-                    .unwrap();
+                    .unwrap_or_default();
                 kwargs
                     .set_item(
                         "expires",
                         cookie.expires_datetime().map(|f| f.unix_timestamp()),
                     )
-                    .unwrap();
-                kwargs.set_item("version", 0).unwrap();
+                    .unwrap_or_default();
+                kwargs.set_item("version", 0).unwrap_or_default();
 
                 let rest = PyDict::new(py);
                 if let Some(http_only) = cookie.http_only() {
-                    rest.set_item("HttpOnly", http_only).unwrap();
+                    rest.set_item("HttpOnly", http_only).unwrap_or_default();
                 }
 
                 if let Some(same_site) = cookie.same_site() {
@@ -84,10 +84,10 @@ impl CookieStore for PythonCookieJar {
                         cookie::SameSite::Lax => "Lax",
                         cookie::SameSite::None => "None",
                     };
-                    rest.set_item("SameSite", same_site_str).unwrap();
+                    rest.set_item("SameSite", same_site_str).unwrap_or_default();
                 }
 
-                kwargs.set_item("rest", rest).unwrap();
+                kwargs.set_item("rest", rest).unwrap_or_default();
 
                 let py_cookie = self.cookie_constructor.call(py, (), Some(&kwargs)).unwrap();
 
@@ -110,18 +110,15 @@ impl CookieStore for PythonCookieJar {
 
                     let domain = py_cookie
                         .getattr("domain")
-                        .unwrap()
-                        .extract::<String>()
-                        .unwrap();
+                        .and_then(|attr| attr.extract::<String>())
+                        .unwrap_or_default();
                     let path = py_cookie
                         .getattr("path")
-                        .unwrap()
-                        .extract::<String>()
-                        .unwrap();
+                        .and_then(|attr| attr.extract::<String>())
+                        .unwrap_or_default();
                     let secure = py_cookie
                         .getattr("secure")
-                        .unwrap()
-                        .extract::<bool>()
+                        .and_then(|attr| attr.extract::<bool>())
                         .unwrap_or_default();
 
                     if !domain.is_empty() && !url.host_str().unwrap_or_default().contains(&domain) {
@@ -187,7 +184,9 @@ impl PythonCookieJar {
         }
     }
 
-    pub fn from_httpx_cookies(py: Python<'_>, cookies: Py<PyAny>) -> Self {
-        PythonCookieJar::new(py, cookies.getattr(py, "jar").unwrap())
+    pub fn from_httpx_cookies(py: Python<'_>, cookies: Py<PyAny>) -> PyResult<Self> {
+        cookies.getattr(py, "jar").and_then(|jar| {
+            Ok(PythonCookieJar::new(py, jar.into()))
+        })
     }
 }

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -2,7 +2,7 @@ use tokio::sync::RwLock;
 
 use log::debug;
 use reqwest::{cookie::CookieStore, header::HeaderMap, Method, Response, Version};
-use std::{fmt::Debug, net::IpAddr, str::FromStr, sync::Arc, time::Duration};
+use std::{fmt::Debug, net::IpAddr, sync::Arc, time::Duration};
 use url::Url;
 
 use crate::{
@@ -100,7 +100,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Default for ImpitBuilder<CookieStor
             browser: None,
             ignore_tls_errors: false,
             vanilla_fallback: true,
-            proxy_url: String::from_str("").unwrap(),
+            proxy_url: String::new(),
             request_timeout: Duration::from_secs(30),
             max_http_version: Version::HTTP_2,
             redirect: RedirectBehavior::FollowRedirect(10),
@@ -325,7 +325,11 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             if engine_guard.is_none() {
                 *engine_guard = Some(H3Engine::init().await);
             }
-            engine_guard.as_ref().unwrap().host_supports_h3(host).await
+
+            match engine_guard.as_ref() {
+                None => false,
+                Some(engine) => engine.host_supports_h3(host).await,
+            }
         }
     }
 
@@ -343,7 +347,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
         }
 
         let parsed_url = self.parse_url(url.clone())?;
-        let host = parsed_url.host_str().unwrap().to_string();
+        let host = parsed_url.host_str().unwrap_or_default().to_string();
 
         let h3 = options.http3_prior_knowledge || self.should_use_h3(&host).await;
 
@@ -357,7 +361,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
 
         let client = if h3 {
             debug!("Using QUIC for request to {url}");
-            self.h3_client.as_ref().unwrap()
+            self.h3_client.as_ref().unwrap_or(&self.base_client)
         } else {
             debug!("{url} doesn't seem to have HTTP3 support");
             &self.base_client
@@ -384,25 +388,26 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
 
         let response = request.send().await;
 
-        if response.is_err() {
-            let max_redirects = match self.config.redirect {
-                RedirectBehavior::FollowRedirect(max) => max,
-                RedirectBehavior::ManualRedirect => 0,
-            };
+        let response = match response {
+            Ok(resp) => resp,
+            Err(err) => {
+                let max_redirects = match self.config.redirect {
+                    RedirectBehavior::FollowRedirect(max) => max,
+                    RedirectBehavior::ManualRedirect => 0,
+                };
 
-            return Err(ImpitError::from(
-                response.err().unwrap(),
-                ErrorContext {
-                    timeout: options.timeout.unwrap_or(self.config.request_timeout),
-                    max_redirects,
-                    method: method.to_string(),
-                    protocol: parsed_url.scheme().to_string(),
-                    url: url.clone(),
-                },
-            ));
-        }
-
-        let response = response.unwrap();
+                return Err(ImpitError::from(
+                    err,
+                    ErrorContext {
+                        timeout: options.timeout.unwrap_or(self.config.request_timeout),
+                        max_redirects,
+                        method: method.to_string(),
+                        protocol: parsed_url.scheme().to_string(),
+                        url: url.clone(),
+                    },
+                ));
+            }
+        };
 
         if !h3 {
             let engine_guard = self.h3_engine.read().await;
@@ -410,10 +415,13 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
                 h3_engine.set_h3_support(&host, false).await;
 
                 if let Some(alt_svc) = response.headers().get("Alt-Svc") {
-                    let alt_svc = alt_svc.to_str().unwrap();
-                    if alt_svc.contains("h3") {
-                        debug!("{host} supports HTTP/3 (alt-svc header), adding to Alt-Svc cache");
-                        h3_engine.set_h3_support(&host, true).await;
+                    if let Ok(alt_svc_str) = alt_svc.to_str() {
+                        if alt_svc_str.contains("h3") {
+                            debug!(
+                                "{host} supports HTTP/3 (alt-svc header), adding to Alt-Svc cache"
+                            );
+                            h3_engine.set_h3_support(&host, true).await;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Lowers the risk of rogue `panic`s by removing the unnecessary (and potentially dangerous) `.unwrap()` calls in Impit codebase.