### PR TITLE
feat: include error message in `ConnectError`

### DIFF
--- a/impit-python/src/errors.rs
+++ b/impit-python/src/errors.rs
@@ -56,7 +56,9 @@ impl From<ImpitPyError> for pyo3::PyErr {
             ImpitPyError(ImpitError::WriteTimeout) => WriteTimeout::new_err(format!("{}", err.0)),
             ImpitPyError(ImpitError::PoolTimeout) => PoolTimeout::new_err(format!("{}", err.0)),
             ImpitPyError(ImpitError::NetworkError) => NetworkError::new_err(format!("{}", err.0)),
-            ImpitPyError(ImpitError::ConnectError) => ConnectError::new_err(format!("{}", err.0)),
+            ImpitPyError(ImpitError::ConnectError(_)) => {
+                ConnectError::new_err(format!("{}", err.0))
+            }
             ImpitPyError(ImpitError::ReadError) => ReadError::new_err(format!("{}", err.0)),
             ImpitPyError(ImpitError::WriteError) => WriteError::new_err(format!("{}", err.0)),
             ImpitPyError(ImpitError::CloseError) => CloseError::new_err(format!("{}", err.0)),

--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -115,12 +115,6 @@ impl ImpitError {
                     }
                 }
 
-                if format!("{source_error:#?}").contains("Tunnel") {
-                    return ImpitError::ProxyError(String::from(
-                        "Connection to the proxy server failed.",
-                    ));
-                }
-
                 if source_error.is_connect() {
                     return ImpitError::ConnectError(format!("{source_error:#?}"));
                 }

--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -115,8 +115,6 @@ impl ImpitError {
                     }
                 }
 
-                println!("{source_error:#?}");
-
                 if format!("{source_error:#?}").contains("Tunnel") {
                     return ImpitError::ProxyError(String::from(
                         "Connection to the proxy server failed.",

--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -34,8 +34,8 @@ pub enum ImpitError {
     PoolTimeout,
     #[error("Network error occurred.")]
     NetworkError,
-    #[error("Failed to connect to the server.")]
-    ConnectError,
+    #[error("Failed to connect to the server.\nReason: {0}")]
+    ConnectError(String),
     #[error("Failed to read data from the server.")]
     ReadError,
     #[error("Failed to write data to the server.")]
@@ -107,16 +107,24 @@ impl ImpitError {
                 .source()
                 .and_then(|e| e.downcast_ref::<hyper_util::client::legacy::Error>())
             {
-                if source_error.is_connect() {
-                    return ImpitError::ConnectError;
-                }
-
                 if let Some(e) = source_error.source() {
                     if let Some(hyper_error) = e.downcast_ref::<hyper::Error>() {
                         if hyper_error.is_incomplete_message() {
                             return ImpitError::RemoteProtocolError;
                         }
                     }
+                }
+
+                println!("{source_error:#?}");
+
+                if format!("{source_error:#?}").contains("Tunnel") {
+                    return ImpitError::ProxyError(String::from(
+                        "Connection to the proxy server failed.",
+                    ));
+                }
+
+                if source_error.is_connect() {
+                    return ImpitError::ConnectError(format!("{source_error:#?}"));
                 }
             }
         }


### PR DESCRIPTION
Injects `cause` to the `ConnectError` display string. This allows for better error introspection in dependent packages.

Unblocks https://github.com/apify/crawlee-python/pull/1389/