### PR TITLE
chore(ci): enable Python builds on `linux-aarch64`

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -49,8 +49,8 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-        #   - runner: ubuntu-22.04
-        #     target: aarch64
+          - runner: ubuntu-22.04
+            target: aarch64
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Enables `aarch64` build, which (when published on PyPI) will allow for `impit` usage on `arm64`-powered Linux instances (like AWS EC2 on Graviton CPUs, but also other).

Related to https://github.com/apify/apify-client-python/issues/492