### PR TITLE
refactor: introduce `ImpitRequest` struct for storing all request-related data

### DIFF
--- a/impit/src/http_headers/mod.rs
+++ b/impit/src/http_headers/mod.rs
@@ -2,7 +2,7 @@ use crate::{emulation::Browser, errors::ImpitError};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::{collections::HashSet, str::FromStr};
 
-mod statics;
+pub mod statics;
 
 pub struct HttpHeaders {
     context: HttpHeadersBuilder,
@@ -34,18 +34,6 @@ impl HttpHeaders {
             .custom_headers
             .iter()
             .map(|(k, v)| (k.as_str(), v.as_str()));
-        let pseudo_headers_order: &[&str] = match self.context.browser {
-            Some(Browser::Chrome) => statics::CHROME_PSEUDOHEADERS_ORDER.as_ref(),
-            Some(Browser::Firefox) => statics::FIREFOX_PSEUDOHEADERS_ORDER.as_ref(),
-            None => &[],
-        };
-
-        if !pseudo_headers_order.is_empty() {
-            std::env::set_var(
-                "IMPIT_H2_PSEUDOHEADERS_ORDER",
-                pseudo_headers_order.join(","),
-            );
-        }
 
         let mut used_header_names: HashSet<String> = HashSet::new();
 
@@ -59,6 +47,14 @@ impl HttpHeaders {
                     Some((name.to_string(), value.to_string()))
                 }
             })
+    }
+}
+
+impl From<Vec<(String, String)>> for HttpHeaders {
+    fn from(val: Vec<(String, String)>) -> Self {
+        let mut builder = HttpHeaders::get_builder();
+        builder.with_custom_headers(Some(val));
+        builder.build()
     }
 }
 

--- a/impit/src/request.rs
+++ b/impit/src/request.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use url::Url;
+
 /// A struct that holds the request options.
 ///
 /// Unlike the [`ImpitBuilder`](crate::impit::ImpitBuilder) struct, these options are specific to a single request.
@@ -16,4 +18,11 @@ pub struct RequestOptions {
     ///
     /// If [`ImpitBuilder::with_http3`](crate::impit::ImpitBuilder::with_http3) wasn't called, this option will cause [`ErrorType::Http3Disabled`](crate::impit::ErrorType::Http3Disabled) errors.
     pub http3_prior_knowledge: bool,
+}
+
+pub struct ImpitRequest {
+    pub url: Url,
+    pub body: Option<Vec<u8>>,
+    pub headers: Vec<(String, String)>,
+    pub method: String,
 }


### PR DESCRIPTION
Refactors the `impit.make_request` method by splitting it into `build_request` and `send`. 

Prerequisite for the solution to #227 proposed in https://github.com/apify/impit/issues/227#issuecomment-3184109259