### PR TITLE
chore: pin forked dependencies by commit hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "h2"
 version = "0.4.7"
-source = "git+https://github.com/apify/h2?branch=master#7f393a728a8db07cabb1b78d2094772b33943b9a"
+source = "git+https://github.com/apify/h2?rev=7f393a728a8db07cabb1b78d2094772b33943b9a#7f393a728a8db07cabb1b78d2094772b33943b9a"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.29"
-source = "git+https://github.com/apify/rustls?branch=main#f384c6c18eb2bfe850d142a4cc7dfe5dc376e7e3"
+source = "git+https://github.com/apify/rustls?rev=f384c6c18eb2bfe850d142a4cc7dfe5dc376e7e3#f384c6c18eb2bfe850d142a4cc7dfe5dc376e7e3"
 dependencies = [
  "aws-lc-rs",
  "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ members = [
 ]
 
 [patch.crates-io]
-h2 = { git = "https://github.com/apify/h2", branch = "master" }
-rustls = { git = "https://github.com/apify/rustls", branch = "main" }
+h2 = { git = "https://github.com/apify/h2", rev = "7f393a728a8db07cabb1b78d2094772b33943b9a" }
+rustls = { git = "https://github.com/apify/rustls", rev = "f384c6c18eb2bfe850d142a4cc7dfe5dc376e7e3" }
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.


### PR DESCRIPTION
Ensures safety from breaking changes while merging larger changes from upstream repos into the custom forks.