### PR TITLE
ci: use napi cross compile toolchain to build node native addon

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -39,8 +39,7 @@ jobs:
             target: x86_64-pc-windows-msvc
           - host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
-            build: yarn --cwd impit-node build --target x86_64-unknown-linux-gnu
+            build: yarn --cwd impit-node build --target x86_64-unknown-linux-gnu --use-napi-cross
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             docker: arm64v8/node:20-alpine
@@ -57,7 +56,7 @@ jobs:
                 yarn --cwd impit-node build
           - host: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-            build: yarn --cwd impit-node build --target aarch64-unknown-linux-gnu
+            build: yarn --cwd impit-node build --target aarch64-unknown-linux-gnu --use-napi-cross
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
             docker: node:20-alpine


### PR DESCRIPTION
The image `ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian` is no longer maintained. The `--use-napi-cross` flag utilizes the same toolchain within this Docker container to compile the Node.js addon, ensuring compatibility with GLIBC 2.17.

Changing this flag will speed up the CI process, as there will be no need to download the entire Docker image.