### PR TITLE
feat: enable `TRACE` method in the bindings

### DIFF
--- a/impit-cli/src/main.rs
+++ b/impit-cli/src/main.rs
@@ -135,7 +135,7 @@ async fn main() {
         Method::Patch => client.patch(args.url, body, Some(options)).await.unwrap(),
         Method::Head => client.head(args.url, body, Some(options)).await.unwrap(),
         Method::Options => client.options(args.url, body, Some(options)).await.unwrap(),
-        Method::Trace => client.trace(args.url, Some(options)).await.unwrap(),
+        Method::Trace => client.trace(args.url, body, Some(options)).await.unwrap(),
     };
 
     print!("{}", response.text().await.unwrap());

--- a/impit-node/index.d.ts
+++ b/impit-node/index.d.ts
@@ -65,7 +65,7 @@ export declare class Impit {
    * });
    * ```
    */
-  fetch(input: string | URL | Request, init?: RequestInit): Promise<ImpitResponse>
+  fetch(resource: string | URL | Request, init?: RequestInit): Promise<ImpitResponse>
 }
 export type ImpitWrapper = Impit
 
@@ -206,7 +206,8 @@ export type HttpMethod =  'GET'|
 'DELETE'|
 'PATCH'|
 'HEAD'|
-'OPTIONS';
+'OPTIONS'|
+'TRACE';
 
 /**
  * Options for configuring an {@link Impit} instance.

--- a/impit-node/index.js
+++ b/impit-node/index.js
@@ -80,8 +80,8 @@ function requireNative() {
       try {
         const binding = require('impit-android-arm64')
         const bindingPackageVersion = require('impit-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -96,8 +96,8 @@ function requireNative() {
       try {
         const binding = require('impit-android-arm-eabi')
         const bindingPackageVersion = require('impit-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -116,8 +116,8 @@ function requireNative() {
       try {
         const binding = require('impit-win32-x64-msvc')
         const bindingPackageVersion = require('impit-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -132,8 +132,8 @@ function requireNative() {
       try {
         const binding = require('impit-win32-ia32-msvc')
         const bindingPackageVersion = require('impit-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -148,8 +148,8 @@ function requireNative() {
       try {
         const binding = require('impit-win32-arm64-msvc')
         const bindingPackageVersion = require('impit-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
     try {
       const binding = require('impit-darwin-universal')
       const bindingPackageVersion = require('impit-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -183,8 +183,8 @@ function requireNative() {
       try {
         const binding = require('impit-darwin-x64')
         const bindingPackageVersion = require('impit-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -199,8 +199,8 @@ function requireNative() {
       try {
         const binding = require('impit-darwin-arm64')
         const bindingPackageVersion = require('impit-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -219,8 +219,8 @@ function requireNative() {
       try {
         const binding = require('impit-freebsd-x64')
         const bindingPackageVersion = require('impit-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -235,8 +235,8 @@ function requireNative() {
       try {
         const binding = require('impit-freebsd-arm64')
         const bindingPackageVersion = require('impit-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -256,8 +256,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-x64-musl')
           const bindingPackageVersion = require('impit-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -272,8 +272,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-x64-gnu')
           const bindingPackageVersion = require('impit-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -290,8 +290,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-arm64-musl')
           const bindingPackageVersion = require('impit-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -306,8 +306,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-arm64-gnu')
           const bindingPackageVersion = require('impit-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -324,8 +324,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-arm-musleabihf')
           const bindingPackageVersion = require('impit-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -340,8 +340,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-arm-gnueabihf')
           const bindingPackageVersion = require('impit-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -358,8 +358,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-loong64-musl')
           const bindingPackageVersion = require('impit-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -374,8 +374,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-loong64-gnu')
           const bindingPackageVersion = require('impit-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-riscv64-musl')
           const bindingPackageVersion = require('impit-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
         try {
           const binding = require('impit-linux-riscv64-gnu')
           const bindingPackageVersion = require('impit-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -425,8 +425,8 @@ function requireNative() {
       try {
         const binding = require('impit-linux-ppc64-gnu')
         const bindingPackageVersion = require('impit-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -441,8 +441,8 @@ function requireNative() {
       try {
         const binding = require('impit-linux-s390x-gnu')
         const bindingPackageVersion = require('impit-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -461,8 +461,8 @@ function requireNative() {
       try {
         const binding = require('impit-openharmony-arm64')
         const bindingPackageVersion = require('impit-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -477,8 +477,8 @@ function requireNative() {
       try {
         const binding = require('impit-openharmony-x64')
         const bindingPackageVersion = require('impit-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -493,8 +493,8 @@ function requireNative() {
       try {
         const binding = require('impit-openharmony-arm')
         const bindingPackageVersion = require('impit-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.6.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/impit-node/src/lib.rs
+++ b/impit-node/src/lib.rs
@@ -144,6 +144,7 @@ impl ImpitWrapper {
         HttpMethod::Delete => self.inner.delete(url, body, request_options).await,
         HttpMethod::Patch => self.inner.patch(url, body, request_options).await,
         HttpMethod::Options => self.inner.options(url, body, request_options).await,
+        HttpMethod::Trace => self.inner.trace(url, body, request_options).await,
       }
     };
 

--- a/impit-node/src/request.rs
+++ b/impit-node/src/request.rs
@@ -13,6 +13,7 @@ pub enum HttpMethod {
   Patch,
   Head,
   Options,
+  Trace,
 }
 
 /// Options for configuring an individual HTTP request.

--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -2500,58 +2500,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.7.1":
-  version: 0.7.1
-  resolution: "impit-darwin-arm64@npm:0.7.1"
+"impit-darwin-arm64@npm:0.7.2":
+  version: 0.7.2
+  resolution: "impit-darwin-arm64@npm:0.7.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.7.1":
-  version: 0.7.1
-  resolution: "impit-darwin-x64@npm:0.7.1"
+"impit-darwin-x64@npm:0.7.2":
+  version: 0.7.2
+  resolution: "impit-darwin-x64@npm:0.7.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.7.1":
-  version: 0.7.1
-  resolution: "impit-linux-arm64-gnu@npm:0.7.1"
+"impit-linux-arm64-gnu@npm:0.7.2":
+  version: 0.7.2
+  resolution: "impit-linux-arm64-gnu@npm:0.7.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.7.1":
-  version: 0.7.1
-  resolution: "impit-linux-arm64-musl@npm:0.7.1"
+"impit-linux-arm64-musl@npm:0.7.2":
+  version: 0.7.2
+  resolution: "impit-linux-arm64-musl@npm:0.7.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.7.1":
-  version: 0.7.1
-  resolution: "impit-linux-x64-gnu@npm:0.7.1"
+"impit-linux-x64-gnu@npm:0.7.2":
+  version: 0.7.2
+  resolution: "impit-linux-x64-gnu@npm:0.7.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.7.1":
-  version: 0.7.1
-  resolution: "impit-linux-x64-musl@npm:0.7.1"
+"impit-linux-x64-musl@npm:0.7.2":
+  version: 0.7.2
+  resolution: "impit-linux-x64-musl@npm:0.7.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.7.1":
-  version: 0.7.1
-  resolution: "impit-win32-arm64-msvc@npm:0.7.1"
+"impit-win32-arm64-msvc@npm:0.7.2":
+  version: 0.7.2
+  resolution: "impit-win32-arm64-msvc@npm:0.7.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.7.1":
-  version: 0.7.1
-  resolution: "impit-win32-x64-msvc@npm:0.7.1"
+"impit-win32-x64-msvc@npm:0.7.2":
+  version: 0.7.2
+  resolution: "impit-win32-x64-msvc@npm:0.7.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2564,14 +2564,14 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^24.0.0"
     express: "npm:^5.0.0"
-    impit-darwin-arm64: "npm:0.7.1"
-    impit-darwin-x64: "npm:0.7.1"
-    impit-linux-arm64-gnu: "npm:0.7.1"
-    impit-linux-arm64-musl: "npm:0.7.1"
-    impit-linux-x64-gnu: "npm:0.7.1"
-    impit-linux-x64-musl: "npm:0.7.1"
-    impit-win32-arm64-msvc: "npm:0.7.1"
-    impit-win32-x64-msvc: "npm:0.7.1"
+    impit-darwin-arm64: "npm:0.7.2"
+    impit-darwin-x64: "npm:0.7.2"
+    impit-linux-arm64-gnu: "npm:0.7.2"
+    impit-linux-arm64-musl: "npm:0.7.2"
+    impit-linux-x64-gnu: "npm:0.7.2"
+    impit-linux-x64-musl: "npm:0.7.2"
+    impit-win32-arm64-msvc: "npm:0.7.2"
+    impit-win32-x64-msvc: "npm:0.7.2"
     proxy-chain: "npm:^2.5.9"
     socks-server-lib: "npm:^0.0.3"
     tough-cookie: "npm:^6.0.0"

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -429,7 +429,7 @@ impl AsyncClient {
                 "patch" => impit.patch(url, Some(body), Some(options)).await,
                 "put" => impit.put(url, Some(body), Some(options)).await,
                 "options" => impit.options(url, Some(body), Some(options)).await,
-                "trace" => impit.trace(url, Some(options)).await,
+                "trace" => impit.trace(url, Some(body), Some(options)).await,
                 "head" => impit.head(url, Some(body), Some(options)).await,
                 "delete" => impit.delete(url, Some(body), Some(options)).await,
                 _ => Err(ImpitError::InvalidMethod(method_str.to_string())),

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -418,7 +418,7 @@ impl Client {
                     "patch" => self.impit.patch(url, Some(body), Some(options)).await,
                     "put" => self.impit.put(url, Some(body), Some(options)).await,
                     "options" => self.impit.options(url, Some(body), Some(options)).await,
-                    "trace" => self.impit.trace(url, Some(options)).await,
+                    "trace" => self.impit.trace(url, Some(body), Some(options)).await,
                     "head" => self.impit.head(url, Some(body), Some(options)).await,
                     "delete" => self.impit.delete(url, Some(body), Some(options)).await,
                     _ => Err(ImpitError::InvalidMethod(method.to_string())),

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -549,9 +549,10 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn trace(
         &self,
         url: String,
+        body: Option<Vec<u8>>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
-        self.make_request(Method::TRACE, url, None, options).await
+        self.make_request(Method::TRACE, url, body, options).await
     }
 
     /// Makes a `DELETE` request to the specified URL.


### PR DESCRIPTION
Unifies all clients by enabling the `trace` method in all of them. Required for type parity (`HttpMethod`) in downstream repositories - Crawlee et al.