### PR TITLE
fix(js): throw `Error` on invalid header value (do not panic)

### DIFF
--- a/impit-node/src/lib.rs
+++ b/impit-node/src/lib.rs
@@ -149,7 +149,7 @@ impl ImpitWrapper {
     };
 
     match response {
-      Ok(response) => Ok(ImpitResponse::from(response)),
+      Ok(response) => ImpitResponse::try_from_response(response),
       Err(err) => {
         let status = match err {
           ImpitError::UrlMissingHostnameError(_) => napi::Status::InvalidArg,


### PR DESCRIPTION
Unparseable response header values now only return `Error` in the Node bindings instead of panicking and killing the process.

Related to #344 