### PR TITLE
fix: use the `rustls` `Verifier` / `CryptoProvider` cache with custom fingerprints

### DIFF
--- a/impit/src/tls/mod.rs
+++ b/impit/src/tls/mod.rs
@@ -125,7 +125,7 @@ impl TlsConfigBuilder {
         let max_http_version = self.max_http_version;
 
         let (fingerprint, cache_browser) = if let Some(fp) = self.tls_fingerprint {
-            (Some(fp), None)
+            (Some(fp.clone()), Some(fp))
         } else {
             (None, None)
         };


### PR DESCRIPTION
Speeds up repeated client instantiation and lowers the memory footprint if the custom fingerprints are used.

Related to #370 