### PR TITLE
chore: fix URLs in Python bindings tests

### DIFF
--- a/impit-node/yarn.lock
+++ b/impit-node/yarn.lock
@@ -2406,58 +2406,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.9.1":
-  version: 0.9.1
-  resolution: "impit-darwin-arm64@npm:0.9.1"
+"impit-darwin-arm64@npm:0.9.2":
+  version: 0.9.2
+  resolution: "impit-darwin-arm64@npm:0.9.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.9.1":
-  version: 0.9.1
-  resolution: "impit-darwin-x64@npm:0.9.1"
+"impit-darwin-x64@npm:0.9.2":
+  version: 0.9.2
+  resolution: "impit-darwin-x64@npm:0.9.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.9.1":
-  version: 0.9.1
-  resolution: "impit-linux-arm64-gnu@npm:0.9.1"
+"impit-linux-arm64-gnu@npm:0.9.2":
+  version: 0.9.2
+  resolution: "impit-linux-arm64-gnu@npm:0.9.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.9.1":
-  version: 0.9.1
-  resolution: "impit-linux-arm64-musl@npm:0.9.1"
+"impit-linux-arm64-musl@npm:0.9.2":
+  version: 0.9.2
+  resolution: "impit-linux-arm64-musl@npm:0.9.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.9.1":
-  version: 0.9.1
-  resolution: "impit-linux-x64-gnu@npm:0.9.1"
+"impit-linux-x64-gnu@npm:0.9.2":
+  version: 0.9.2
+  resolution: "impit-linux-x64-gnu@npm:0.9.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.9.1":
-  version: 0.9.1
-  resolution: "impit-linux-x64-musl@npm:0.9.1"
+"impit-linux-x64-musl@npm:0.9.2":
+  version: 0.9.2
+  resolution: "impit-linux-x64-musl@npm:0.9.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.9.1":
-  version: 0.9.1
-  resolution: "impit-win32-arm64-msvc@npm:0.9.1"
+"impit-win32-arm64-msvc@npm:0.9.2":
+  version: 0.9.2
+  resolution: "impit-win32-arm64-msvc@npm:0.9.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.9.1":
-  version: 0.9.1
-  resolution: "impit-win32-x64-msvc@npm:0.9.1"
+"impit-win32-x64-msvc@npm:0.9.2":
+  version: 0.9.2
+  resolution: "impit-win32-x64-msvc@npm:0.9.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2470,14 +2470,14 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/node": "npm:^24.0.0"
     express: "npm:^5.0.0"
-    impit-darwin-arm64: "npm:0.9.1"
-    impit-darwin-x64: "npm:0.9.1"
-    impit-linux-arm64-gnu: "npm:0.9.1"
-    impit-linux-arm64-musl: "npm:0.9.1"
-    impit-linux-x64-gnu: "npm:0.9.1"
-    impit-linux-x64-musl: "npm:0.9.1"
-    impit-win32-arm64-msvc: "npm:0.9.1"
-    impit-win32-x64-msvc: "npm:0.9.1"
+    impit-darwin-arm64: "npm:0.9.2"
+    impit-darwin-x64: "npm:0.9.2"
+    impit-linux-arm64-gnu: "npm:0.9.2"
+    impit-linux-arm64-musl: "npm:0.9.2"
+    impit-linux-x64-gnu: "npm:0.9.2"
+    impit-linux-x64-musl: "npm:0.9.2"
+    impit-win32-arm64-msvc: "npm:0.9.2"
+    impit-win32-x64-msvc: "npm:0.9.2"
     proxy-chain: "npm:^2.5.9"
     socks-server-lib: "npm:^0.0.3"
     tough-cookie: "npm:^6.0.0"

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -188,7 +188,7 @@ class TestBasicRequests:
         response = json.loads(
             (
                 await impit.get(
-                    get_httpbin_url('/cookies/'),
+                    get_httpbin_url('/cookies'),
                 )
             ).text
         )
@@ -202,7 +202,7 @@ class TestBasicRequests:
         response = json.loads(
             (
                 await impit.get(
-                    get_httpbin_url('/cookies/'),
+                    get_httpbin_url('/cookies'),
                 )
             ).text
         )
@@ -226,7 +226,7 @@ class TestBasicRequests:
         response = json.loads(
             (
                 await impit.get(
-                    get_httpbin_url('/cookies/'),
+                    get_httpbin_url('/cookies'),
                 )
             ).text
         )
@@ -240,7 +240,7 @@ class TestBasicRequests:
         response = json.loads(
             (
                 await impit.get(
-                    get_httpbin_url('/cookies/'),
+                    get_httpbin_url('/cookies'),
                 )
             ).text
         )

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -184,7 +184,7 @@ class TestBasicRequests:
         )
 
         response = impit.get(
-            get_httpbin_url('/cookies/'),
+            get_httpbin_url('/cookies'),
         ).json()
 
         assert response['cookies'] == {'preset-cookie': '123'}
@@ -194,7 +194,7 @@ class TestBasicRequests:
         )
 
         response = impit.get(
-            get_httpbin_url('/cookies/'),
+            get_httpbin_url('/cookies'),
         ).json()
 
         assert response['cookies'] == {
@@ -213,7 +213,7 @@ class TestBasicRequests:
         )
 
         response = impit.get(
-            get_httpbin_url('/cookies/'),
+            get_httpbin_url('/cookies'),
         ).json()
 
         assert response['cookies'] == {'preset-cookie': '123'}
@@ -223,7 +223,7 @@ class TestBasicRequests:
         )
 
         response = impit.get(
-            get_httpbin_url('/cookies/'),
+            get_httpbin_url('/cookies'),
         ).json()
 
         assert response['cookies'] == {

--- a/impit-python/test/no_client_test.py
+++ b/impit-python/test/no_client_test.py
@@ -122,7 +122,7 @@ class TestBasicRequests:
         cookies = Cookies({'preset-cookie': '123'})
 
         response = impit.get(
-            get_httpbin_url('/cookies/'),
+            get_httpbin_url('/cookies'),
             cookie_jar=cookies.jar,
         ).json()
 
@@ -134,7 +134,7 @@ class TestBasicRequests:
         )
 
         response = impit.get(
-            get_httpbin_url('/cookies/'),
+            get_httpbin_url('/cookies'),
             cookie_jar=cookies.jar,
         ).json()
 
@@ -149,7 +149,7 @@ class TestBasicRequests:
         cookies = Cookies({'preset-cookie': '123'})
 
         response = impit.get(
-            get_httpbin_url('/cookies/'),
+            get_httpbin_url('/cookies'),
             cookies=cookies,
         ).json()
 
@@ -161,7 +161,7 @@ class TestBasicRequests:
         )
 
         response = impit.get(
-            get_httpbin_url('/cookies/'),
+            get_httpbin_url('/cookies'),
             cookies=cookies,
         ).json()
 


### PR DESCRIPTION
Drops trailing slash in the testing HTTPBin `cookies/` url. The trailing slash leads to 404 errors. 