### PR TITLE
[impit-node][feat] Throw Response as maximum redirect limit Error cause

### DIFF
--- a/impit-node/errors.js
+++ b/impit-node/errors.js
@@ -75,7 +75,7 @@ function rethrowNativeError(err) {
         const [, code, message] = match;
         const ErrorClass = errorClassMap[code];
         if (ErrorClass) {
-            throw new ErrorClass(message);
+            throw new ErrorClass(message, { cause: err.cause });
         }
     }
     throw err;

--- a/impit-node/errors.js
+++ b/impit-node/errors.js
@@ -1,4 +1,9 @@
-class ImpitError extends Error { constructor(msg) { super(msg); this.name = this.constructor.name; } }
+class ImpitError extends Error {
+    constructor(msg, options) {
+        super(msg, options);
+        this.name = this.constructor.name;
+    }
+}
 class HTTPError extends ImpitError {}
 class RequestError extends ImpitError {}
 class TransportError extends RequestError {}

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -238,7 +238,7 @@ class Impit extends native.Impit {
 
                     redirectCount++;
                     if (redirectCount > maxRedirects) {
-                        throw new Error(`Maximum redirect limit (${maxRedirects}) exceeded`);
+                        throw new Error(`Maximum redirect limit (${maxRedirects}) exceeded`, { cause: response });
                     }
 
                     url = new URL(location, url).toString();

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -194,65 +194,67 @@ class Impit extends native.Impit {
         const errorOnRedirect = redirect === 'error';
         let lastResponse = null;
 
-        while (true) {
-            signal?.throwIfAborted();
+        try {
+            while (true) {
+                signal?.throwIfAborted();
 
-            const headers = [...(options.headers || [])];
-            const hasUserCookie = headers.some(([k]) => k.toLowerCase() === 'cookie');
+                const headers = [...(options.headers || [])];
+                const hasUserCookie = headers.some(([k]) => k.toLowerCase() === 'cookie');
 
-            if (this.#cookieJar && !hasUserCookie) {
-                const cookieHeader = await this.#getCookies(url);
-                if (cookieHeader) {
-                    headers.push(['Cookie', cookieHeader]);
-                }
-            }
-
-            const response = super.fetch(url, {
-                ...options,
-                method,
-                headers,
-                body: method === 'GET' ? undefined : options.body,
-            });
-
-            const originalResponse = await Promise.race([
-                response,
-                waitForAbort
-            ]).catch((e) => {
-                e.cause = lastResponse;
-                throw e;
-            });
-
-            lastResponse = this.#wrapResponse(originalResponse, signal);
-
-            if (this.#cookieJar) {
-                await this.#setCookies(lastResponse.headers, url);
-            }
-
-            if (isRedirectStatus(originalResponse.status)) {
-                if (errorOnRedirect) {
-                    throw new TypeError(`URI requested responds with a redirect, redirect mode is set to 'error': ${url}`);
+                if (this.#cookieJar && !hasUserCookie) {
+                    const cookieHeader = await this.#getCookies(url);
+                    if (cookieHeader) {
+                        headers.push(['Cookie', cookieHeader]);
+                    }
                 }
 
-                if (followRedirects) {
-                    const location = lastResponse.headers.get('location');
+                const response = super.fetch(url, {
+                    ...options,
+                    method,
+                    headers,
+                    body: method === 'GET' ? undefined : options.body,
+                });
 
-                    if (!location) {
-                        return lastResponse;
+                const originalResponse = await Promise.race([
+                    response,
+                    waitForAbort
+                ]);
+
+                lastResponse = this.#wrapResponse(originalResponse, signal);
+
+                if (this.#cookieJar) {
+                    await this.#setCookies(lastResponse.headers, url);
+                }
+
+                if (isRedirectStatus(originalResponse.status)) {
+                    if (errorOnRedirect) {
+                        throw new TypeError(`URI requested responds with a redirect, redirect mode is set to 'error': ${url}`);
                     }
 
-                    redirectCount++;
-                    if (redirectCount > maxRedirects) {
-                        throw new Error(`Maximum redirect limit (${maxRedirects}) exceeded`, { cause: lastResponse });
+                    if (followRedirects) {
+                        const location = lastResponse.headers.get('location');
+
+                        if (!location) {
+                            return lastResponse;
+                        }
+
+                        redirectCount++;
+                        if (redirectCount > maxRedirects) {
+                            throw new Error(`Maximum redirect limit (${maxRedirects}) exceeded`, { cause: lastResponse });
+                        }
+
+                        url = new URL(location, url).toString();
+                        method = shouldRewriteRedirectToGet(originalResponse.status, method) ? 'GET' : method;
+
+                        continue;
                     }
-
-                    url = new URL(location, url).toString();
-                    method = shouldRewriteRedirectToGet(originalResponse.status, method) ? 'GET' : method;
-
-                    continue;
                 }
-            }
 
-            return lastResponse;
+                return lastResponse;
+            }
+        } catch (e) {
+            e.cause = lastResponse;
+            throw e;
         }
     }
 

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -192,6 +192,7 @@ class Impit extends native.Impit {
             ? redirect === 'follow'
             : this.#followRedirects;
         const errorOnRedirect = redirect === 'error';
+        let lastResponse = null;
 
         while (true) {
             signal?.throwIfAborted();
@@ -216,12 +217,15 @@ class Impit extends native.Impit {
             const originalResponse = await Promise.race([
                 response,
                 waitForAbort
-            ]);
+            ]).catch((e) => {
+                e.cause = lastResponse;
+                throw e;
+            });
 
-            const responseHeaders = new Headers(originalResponse.headers);
+            lastResponse = this.#wrapResponse(originalResponse, signal);
 
             if (this.#cookieJar) {
-                await this.#setCookies(responseHeaders, url);
+                await this.#setCookies(lastResponse.headers, url);
             }
 
             if (isRedirectStatus(originalResponse.status)) {
@@ -230,17 +234,15 @@ class Impit extends native.Impit {
                 }
 
                 if (followRedirects) {
-                    const location = responseHeaders.get('location');
+                    const location = lastResponse.headers.get('location');
 
                     if (!location) {
-                        return this.#wrapResponse(originalResponse, signal);
+                        return lastResponse;
                     }
 
                     redirectCount++;
                     if (redirectCount > maxRedirects) {
-                        throw new Error(`Maximum redirect limit (${maxRedirects}) exceeded`, {
-                            cause: this.#wrapResponse(originalResponse, signal),
-                        });
+                        throw new Error(`Maximum redirect limit (${maxRedirects}) exceeded`, { cause: lastResponse });
                     }
 
                     url = new URL(location, url).toString();
@@ -250,7 +252,7 @@ class Impit extends native.Impit {
                 }
             }
 
-            return this.#wrapResponse(originalResponse, signal);
+            return lastResponse;
         }
     }
 

--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -238,7 +238,9 @@ class Impit extends native.Impit {
 
                     redirectCount++;
                     if (redirectCount > maxRedirects) {
-                        throw new Error(`Maximum redirect limit (${maxRedirects}) exceeded`, { cause: response });
+                        throw new Error(`Maximum redirect limit (${maxRedirects}) exceeded`, {
+                            cause: this.#wrapResponse(originalResponse, signal),
+                        });
                     }
 
                     url = new URL(location, url).toString();

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -855,5 +855,22 @@ describe.each([
             expect(response.status).toBe(307);
             expect(response.headers.get('location')).toBe('/get');
         });
+
+        test('throws final redirect as error cause', async () => {
+            const limited = new Impit({ maxRedirects: 1 });
+
+            let error: Error | undefined;
+            try {
+                await limited.fetch('http://localhost:3001/redirect/2');
+            } catch (cause) {
+                error = cause as Error;
+            }
+
+            expect(error).toBe(expect.any(Error));
+            const response = error!.cause as Response;
+            expect(response).toBe(expect.any(Response));
+            expect(response.url).toBe('http://localhost:3001/redirect/2');
+            expect(response.headers.get('location')).toBe('/relative-redirect/1');
+        });
     })
 });

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 import { test, describe, expect, beforeAll, afterAll } from 'vitest';
 
-import { HttpMethod, Impit, Browser } from '../index.wrapper.js';
+import { HttpMethod, Impit, Browser, ImpitResponse } from '../index.wrapper.js';
 import type { AddressInfo, Server } from 'net';
 import { routes, runProxyServer, runServer } from './mock.server.js';
 
@@ -858,19 +858,18 @@ describe.each([
 
         test('throws final redirect as error cause', async () => {
             const limited = new Impit({ maxRedirects: 1 });
-
-            let error: Error | undefined;
             try {
                 await limited.fetch('http://localhost:3001/redirect/2');
-            } catch (cause) {
-                error = cause as Error;
+                expect.unreachable('should have thrown');
+            } catch (e) {
+                expect(e).toBeInstanceOf(Error)
+                const error = (e as Error)
+                expect(error.message.startsWith('Maximum redirect limit')).toBe(true)
+                expect(error.cause).toBeInstanceOf(ImpitResponse);
+                const response = error.cause as ImpitResponse;
+                expect(response.url).toBe('http://localhost:3001/redirect/1');
+                expect(response.headers.get('location')).toBe('/get');
             }
-
-            expect(error).toBe(expect.any(Error));
-            const response = error!.cause as Response;
-            expect(response).toBe(expect.any(Response));
-            expect(response.url).toBe('http://localhost:3001/redirect/2');
-            expect(response.headers.get('location')).toBe('/relative-redirect/1');
         });
     })
 });

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -858,13 +858,14 @@ describe.each([
 
         test('throws final redirect as error cause', async () => {
             const limited = new Impit({ maxRedirects: 1 });
+            
             try {
                 await limited.fetch('http://localhost:3001/redirect/2');
                 expect.unreachable('should have thrown');
             } catch (e) {
-                expect(e).toBeInstanceOf(Error)
-                const error = (e as Error)
-                expect(error.message.startsWith('Maximum redirect limit')).toBe(true)
+                expect(e).toBeInstanceOf(Error);
+                const error = e as Error;
+                expect(error.message.startsWith('Maximum redirect limit')).toBe(true);
                 expect(error.cause).toBeInstanceOf(ImpitResponse);
                 const response = error.cause as ImpitResponse;
                 expect(response.url).toBe('http://localhost:3001/redirect/1');

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -8,6 +8,7 @@ import { routes, runProxyServer, runServer } from './mock.server.js';
 import { CookieJar } from 'tough-cookie';
 import { runSocksServer } from 'socks-server-lib';
 import { Server as ProxyServer } from 'proxy-chain';
+import { TimeoutError } from '../index.wrapper.js';
 
 function getHttpBinUrl(path: string, https?: boolean): string {
     https ??= true;
@@ -190,6 +191,7 @@ describe.each([
             const proxyPort = (proxy.address() as AddressInfo)?.port;
 
             const impit = new Impit({
+                browser,
                 proxyUrl: `http://user:@127.0.0.1:${proxyPort}`,
             });
 
@@ -747,7 +749,7 @@ describe.each([
         });
 
         test('instance-level followRedirects: false disables redirects', async () => {
-            const noRedirect = new Impit({ followRedirects: false });
+            const noRedirect = new Impit({ browser, followRedirects: false });
             const response = await noRedirect.fetch('http://localhost:3001/redirect/1');
 
             expect(response.status).toBe(302);
@@ -755,7 +757,7 @@ describe.each([
         });
 
         test('instance-level maxRedirects limits redirect chain', async () => {
-            const limited = new Impit({ maxRedirects: 1 });
+            const limited = new Impit({ browser, maxRedirects: 1 });
 
             await expect(
                 limited.fetch('http://localhost:3001/redirect/2'),
@@ -778,7 +780,7 @@ describe.each([
         });
 
         test('per-request redirect: "follow" follows redirects', async () => {
-            const noRedirect = new Impit({ followRedirects: false });
+            const noRedirect = new Impit({ browser, followRedirects: false });
             const response = await noRedirect.fetch('http://localhost:3001/redirect/1', {
                 redirect: 'follow',
             });
@@ -804,7 +806,7 @@ describe.each([
         });
 
         test('bare Request does not override instance followRedirects: false', async () => {
-            const noRedirect = new Impit({ followRedirects: false });
+            const noRedirect = new Impit({ browser, followRedirects: false });
             const request = new Request('http://localhost:3001/redirect/1');
             const response = await noRedirect.fetch(request);
 
@@ -829,7 +831,7 @@ describe.each([
         });
 
         test('redirect: "follow" still respects instance maxRedirects', async () => {
-            const limited = new Impit({ followRedirects: false, maxRedirects: 1 });
+            const limited = new Impit({ browser, followRedirects: false, maxRedirects: 1 });
 
             await expect(
                 limited.fetch('http://localhost:3001/redirect/2', { redirect: 'follow' }),
@@ -856,8 +858,8 @@ describe.each([
             expect(response.headers.get('location')).toBe('/get');
         });
 
-        test('throws final redirect as error cause', async () => {
-            const limited = new Impit({ maxRedirects: 1 });
+        test('throws last redirect response as error cause when maxRedirects is exceeded', async () => {
+            const limited = new Impit({ browser, maxRedirects: 1 });
             
             try {
                 await limited.fetch('http://localhost:3001/redirect/2');
@@ -870,6 +872,38 @@ describe.each([
                 const response = error.cause as ImpitResponse;
                 expect(response.url).toBe('http://localhost:3001/redirect/1');
                 expect(response.headers.get('location')).toBe('/get');
+            }
+        });
+
+        test('throws last redirect response as error cause when request timeout is exceeded', async () => {
+            try {
+                await impit.fetch('http://localhost:3001/redirect-to?url=/stall/1000', {
+                    timeout: 100,
+                });
+                expect.unreachable('should have thrown');
+            } catch (e) {
+                expect(e).toBeInstanceOf(TimeoutError);
+                const error = e as TimeoutError;
+                expect(error.cause).toBeInstanceOf(ImpitResponse);
+                const response = error.cause as ImpitResponse;
+                expect(response.url).toBe('http://localhost:3001/redirect-to?url=/stall/1000');
+                expect(response.headers.get('location')).toBe('/stall/1000');
+            }
+        });
+
+        test('throws last redirect response as error cause when signal is aborted', async () => {
+            try {
+                await impit.fetch('http://localhost:3001/redirect-to?url=/stall/1000', {
+                    signal: AbortSignal.timeout(100),
+                });
+                expect.unreachable('should have thrown');
+            } catch (e) {
+                expect(e).toBeInstanceOf(DOMException);
+                const error = e as DOMException;
+                expect(error.cause).toBeInstanceOf(ImpitResponse);
+                const response = error.cause as ImpitResponse;
+                expect(response.url).toBe('http://localhost:3001/redirect-to?url=/stall/1000');
+                expect(response.headers.get('location')).toBe('/stall/1000');
             }
         });
     })

--- a/impit-node/test/mock.server.ts
+++ b/impit-node/test/mock.server.ts
@@ -69,6 +69,14 @@ export async function runServer(port: number): Promise<Server> {
         }, delay);
     });
 
+    app.get('/stall/:ms', (req, res) => {
+        const delay = parseInt(req.params.ms, 10);
+
+        setTimeout(() => {
+            res.sendStatus(200);
+        }, delay);
+    });
+
     app.get('/cookies', (req, res) => {
         const cookies: Record<string, string> = {};
         const cookieHeader = req.headers.cookie;


### PR DESCRIPTION


Requirement: I need to know what the final URL was in redirect chains. I would like the final response to be included in thrown errors.

Scenarios:
- (maxRedirects: 1) example.com/redirect -> redirect.com (location: destination.com) -> Error 
- (timeout/AbortSignal) example.com/redirect -> destination.com (never responds) -> Error

Solution: I am including the final response as the cause in the thrown Error.

```ts
const impit = new Impit({ 
  followRedirects: true,
  maxRedirects: 10,
  timeout: 10000,
});

const signal = AbortSignal.timeout(10000);
const response = await impit.fetch(url, { signal }).catch((error) => {
  if (error instanceof Error && error.cause instanceof ImpitResponse) {
    return error.cause;
  }
  throw error;
});
```

Have added tests for this additional behaviour. (also added browser into `impit` test config where it was missing in basics.test.ts)

**Non-breaking change.**