### PR TITLE
fix: decode non-ASCII response header values as ISO-8859-1

### DIFF
--- a/impit-node/src/response.rs
+++ b/impit-node/src/response.rs
@@ -91,15 +91,10 @@ impl<'env> ImpitResponse {
       .to_string();
     let mut headers_vec: Vec<(String, String)> = Vec::new();
     for (k, v) in response.headers().iter() {
-      match v.to_str() {
-        Ok(val) => headers_vec.push((k.as_str().to_string(), val.to_string())),
-        Err(e) => {
-          return Err(napi::Error::new(
-            napi::Status::GenericFailure,
-            format!("Failed to parse header value for '{}': {:?}", k.as_str(), e),
-          ));
-        }
-      }
+      headers_vec.push((
+        k.as_str().to_string(),
+        v.as_bytes().iter().map(|&b| b as char).collect(),
+      ));
     }
     let headers = Headers(headers_vec);
     let ok = response.status().is_success();

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -502,6 +502,11 @@ describe.each([
             t.expect(text).toContain(routes.charsetMetaHttpEquiv.bodyString);
         });
 
+        test('non-ASCII header values are decoded as ISO-8859-1', async (t) => {
+            const response = await impit.fetch(new URL(routes.nonAsciiHeader.path, "http://127.0.0.1:3001").href);
+            t.expect(response.headers.get('x-non-ascii')).toBe(routes.nonAsciiHeader.headerValue);
+        });
+
         test('.json() method works', async (t) => {
         const response = await impit.fetch(getHttpBinUrl('/json'));
         const json = await response.json();

--- a/impit-node/test/mock.server.ts
+++ b/impit-node/test/mock.server.ts
@@ -20,6 +20,10 @@ export const routes = {
         path: '/charset/meta-http-equiv',
         bodyString: WIN1250_STRING,
     },
+    nonAsciiHeader: {
+        path: '/non-ascii-header',
+        headerValue: 'Dienstag, 31. März 2026',
+    },
 }
 
 export async function runServer(port: number): Promise<Server> {
@@ -48,6 +52,21 @@ export async function runServer(port: number): Promise<Server> {
         ]);
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(html);
+    });
+
+    app.get(routes.nonAsciiHeader.path, (req, res) => {
+        const socket = res.socket!;
+        socket.write('HTTP/1.1 200 OK\r\n');
+        socket.write('Content-Type: text/plain\r\n');
+        socket.write(Buffer.concat([
+            Buffer.from('X-Non-Ascii: Dienstag, 31. M'),
+            Buffer.from([0xE4]), // ä in ISO-8859-1
+            Buffer.from('rz 2026\r\n'),
+        ]));
+        socket.write('Content-Length: 2\r\n');
+        socket.write('\r\n');
+        socket.write('ok');
+        socket.end();
     });
 
     app.get('/socket', (req, res) => {

--- a/impit-python/src/response.rs
+++ b/impit-python/src/response.rs
@@ -541,7 +541,7 @@ impl ImpitPyResponse {
         let headers = HashMap::from_iter(val.headers().iter().map(|(k, v)| {
             (
                 k.as_str().to_string(),
-                v.to_str().unwrap_or_default().to_string(),
+                v.as_bytes().iter().map(|&b| b as char).collect(),
             )
         }));
 

--- a/impit-python/src/response.rs
+++ b/impit-python/src/response.rs
@@ -541,7 +541,7 @@ impl ImpitPyResponse {
         let headers = HashMap::from_iter(val.headers().iter().map(|(k, v)| {
             (
                 k.as_str().to_string(),
-                v.as_bytes().iter().map(|&b| b as char).collect(),
+                v.as_bytes().iter().map(|&b| b as char).collect::<String>(),
             )
         }));
 


### PR DESCRIPTION
Fixes #430

`HeaderValue::to_str()` rejects any non-ASCII bytes, which caused Node bindings to crash and Python bindings to silently return empty strings when servers sent headers like `last-modified: Dienstag, 31. März 2026`.

Replaced with a per-byte ISO-8859-1 decode (`b as char`), which maps bytes 0x00–0xFF directly to Unicode codepoints U+0000–U+00FF. This matches the `obs-text` allowance in [RFC 9110 §5.5](https://www.rfc-editor.org/rfc/rfc9110#section-5.5).