### PR TITLE
feat: return the `vanillaFallback` option as an alternative for failing requests

### DIFF
--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -105,6 +105,10 @@ impl From<reqwest::Error> for ImpitError {
 }
 
 impl ImpitError {
+    pub fn is_connect_error(&self) -> bool {
+        matches!(self, ImpitError::ConnectError(_))
+    }
+
     pub fn from(error: reqwest::Error, context: Option<ErrorContext>) -> Self {
         let context = context.unwrap_or_default();
         if error.is_timeout() {

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -22,6 +22,7 @@ use crate::{
 pub struct Impit<CookieStoreImpl: CookieStore + 'static> {
     pub(self) base_client: reqwest::Client,
     pub(self) h3_client: Option<reqwest::Client>,
+    pub(self) vanilla_client: Option<reqwest::Client>,
     h3_engine: Arc<RwLock<Option<H3Engine>>>,
     config: ImpitBuilder<CookieStoreImpl>,
 }
@@ -107,7 +108,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Default for ImpitBuilder<CookieStor
         ImpitBuilder {
             fingerprint: None,
             ignore_tls_errors: false,
-            vanilla_fallback: true,
+            vanilla_fallback: false,
             proxy_url: String::new(),
             request_timeout: Duration::from_secs(30),
             max_http_version: Version::HTTP_2,
@@ -312,6 +313,16 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             })?;
         }
 
+        let vanilla_client = if config.vanilla_fallback && config.fingerprint.is_some() {
+            Some(Self::new_reqwest_client(&ImpitBuilder::<CookieStoreImpl> {
+                fingerprint: None,
+                max_http_version: Version::HTTP_2,
+                ..config.clone()
+            })?)
+        } else {
+            None
+        };
+
         // Set pseudo-header order from fingerprint or fall back to browser enum
         let pseudo_headers_order: Vec<String> = if let Some(ref fingerprint) = config.fingerprint {
             fingerprint.http2.pseudo_header_order.to_vec()
@@ -329,6 +340,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
         Ok(Impit {
             base_client,
             h3_client,
+            vanilla_client,
             config,
             h3_engine: Arc::new(RwLock::new(None)),
         })
@@ -401,6 +413,33 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
         }
     }
 
+    async fn execute_request(
+        &self,
+        client: &reqwest::Client,
+        method: Method,
+        url: Url,
+        headers: HeaderMap,
+        body: Option<Vec<u8>>,
+        timeout: Option<Duration>,
+        h3: bool,
+    ) -> Result<Response, reqwest::Error> {
+        let mut req = client.request(method, url).headers(headers);
+
+        if h3 {
+            req = req.version(Version::HTTP_3);
+        }
+
+        if let Some(t) = timeout {
+            req = req.timeout(t);
+        }
+
+        if let Some(b) = body {
+            req = req.body(b);
+        }
+
+        req.send().await
+    }
+
     async fn send(
         &self,
         request: ImpitRequest,
@@ -426,40 +465,35 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             &self.base_client
         };
 
-        let header_map: Result<HeaderMap, ImpitError> = HttpHeaders::from(request.headers).into();
+        let header_map_result: Result<HeaderMap, ImpitError> =
+            HttpHeaders::from(request.headers).into();
+        let header_map = header_map_result?;
 
         let method = Method::from_str(&request.method).map_err(|_| {
             ImpitError::InvalidMethod(format!("Invalid HTTP method: {}", request.method))
         })?;
 
-        let mut client_request = client
-            .request(method.clone(), request.url.clone())
-            .headers(header_map?);
-
-        if h3 {
-            client_request = client_request.version(Version::HTTP_3);
-        }
-
-        if let Some(timeout) = timeout {
-            client_request = client_request.timeout(timeout);
-        }
-
-        client_request = match request.body {
-            Some(body) => client_request.body(body),
-            None => client_request,
+        let max_redirects = match self.config.redirect {
+            RedirectBehavior::FollowRedirect(max) => max,
+            RedirectBehavior::ManualRedirect => 0,
         };
 
-        let response = client_request.send().await;
+        let primary_result = self
+            .execute_request(
+                client,
+                method.clone(),
+                request.url.clone(),
+                header_map.clone(),
+                request.body.clone(),
+                timeout,
+                h3,
+            )
+            .await;
 
-        let response = match response {
+        let response = match primary_result {
             Ok(resp) => resp,
             Err(err) => {
-                let max_redirects = match self.config.redirect {
-                    RedirectBehavior::FollowRedirect(max) => max,
-                    RedirectBehavior::ManualRedirect => 0,
-                };
-
-                return Err(ImpitError::from(
+                let primary_error = ImpitError::from(
                     err,
                     Some(ErrorContext {
                         timeout: Some(timeout.unwrap_or(self.config.request_timeout)),
@@ -468,7 +502,31 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
                         protocol: Some(request.url.scheme().to_string()),
                         url: Some(url.clone()),
                     }),
-                ));
+                );
+
+                let fallback_client = self.vanilla_client.as_ref().filter(|_| primary_error.is_connect_error());
+                let Some(vanilla_client) = fallback_client else {
+                    return Err(primary_error);
+                };
+
+                debug!(
+                    "Primary request to {url} failed with {primary_error}, retrying with vanilla client"
+                );
+                match self
+                    .execute_request(
+                        vanilla_client,
+                        method.clone(),
+                        request.url.clone(),
+                        header_map,
+                        request.body,
+                        timeout,
+                        false,
+                    )
+                    .await
+                {
+                    Ok(resp) => resp,
+                    Err(_) => return Err(primary_error),
+                }
             }
         };
 

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -27,6 +27,13 @@ pub struct Impit<CookieStoreImpl: CookieStore + 'static> {
     config: ImpitBuilder<CookieStoreImpl>,
 }
 
+struct PreparedRequest {
+    method: Method,
+    url: Url,
+    headers: HeaderMap,
+    body: Option<Vec<u8>>,
+}
+
 impl<CookieStoreImpl: CookieStore + 'static> Default for Impit<CookieStoreImpl> {
     fn default() -> Self {
         ImpitBuilder::<CookieStoreImpl>::default().build().unwrap()
@@ -314,11 +321,13 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
         }
 
         let vanilla_client = if config.vanilla_fallback && config.fingerprint.is_some() {
-            Some(Self::new_reqwest_client(&ImpitBuilder::<CookieStoreImpl> {
-                fingerprint: None,
-                max_http_version: Version::HTTP_2,
-                ..config.clone()
-            })?)
+            Some(Self::new_reqwest_client(
+                &ImpitBuilder::<CookieStoreImpl> {
+                    fingerprint: None,
+                    max_http_version: Version::HTTP_2,
+                    ..config.clone()
+                },
+            )?)
         } else {
             None
         };
@@ -416,14 +425,13 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     async fn execute_request(
         &self,
         client: &reqwest::Client,
-        method: Method,
-        url: Url,
-        headers: HeaderMap,
-        body: Option<Vec<u8>>,
+        prepared: &PreparedRequest,
         timeout: Option<Duration>,
         h3: bool,
     ) -> Result<Response, reqwest::Error> {
-        let mut req = client.request(method, url).headers(headers);
+        let mut req = client
+            .request(prepared.method.clone(), prepared.url.clone())
+            .headers(prepared.headers.clone());
 
         if h3 {
             req = req.version(Version::HTTP_3);
@@ -433,7 +441,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             req = req.timeout(t);
         }
 
-        if let Some(b) = body {
+        if let Some(b) = prepared.body.clone() {
             req = req.body(b);
         }
 
@@ -478,17 +486,14 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             RedirectBehavior::ManualRedirect => 0,
         };
 
-        let primary_result = self
-            .execute_request(
-                client,
-                method.clone(),
-                request.url.clone(),
-                header_map.clone(),
-                request.body.clone(),
-                timeout,
-                h3,
-            )
-            .await;
+        let prepared = PreparedRequest {
+            method: method.clone(),
+            url: request.url.clone(),
+            headers: header_map,
+            body: request.body,
+        };
+
+        let primary_result = self.execute_request(client, &prepared, timeout, h3).await;
 
         let response = match primary_result {
             Ok(resp) => resp,
@@ -504,7 +509,10 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
                     }),
                 );
 
-                let fallback_client = self.vanilla_client.as_ref().filter(|_| primary_error.is_connect_error());
+                let fallback_client = self
+                    .vanilla_client
+                    .as_ref()
+                    .filter(|_| primary_error.is_connect_error());
                 let Some(vanilla_client) = fallback_client else {
                     return Err(primary_error);
                 };
@@ -513,15 +521,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
                     "Primary request to {url} failed with {primary_error}, retrying with vanilla client"
                 );
                 match self
-                    .execute_request(
-                        vanilla_client,
-                        method.clone(),
-                        request.url.clone(),
-                        header_map,
-                        request.body,
-                        timeout,
-                        false,
-                    )
+                    .execute_request(vanilla_client, &prepared, timeout, false)
                     .await
                 {
                     Ok(resp) => resp,


### PR DESCRIPTION
The `vanillaFallback` option has been noop in a few of the latest versions of `impit`. The changes from this PR return this feature to support, e.g., servers with old TLS stacks that uncover some of the emulation discrepancies and cause the requests to fail.

Closes #205 