### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -28,7 +28,7 @@ jobs:
 
     publish:
         outputs:
-          bumped-version-commit-sha: ${{ steps.commit.outputs.commit-sha || github.sha }}
+          bumped-version-commit-sha: ${{ steps.commit.outputs.commit_sha || github.sha }}
           new_version: ${{ steps.get-new-version.outputs.TARGET_VERSION }}
         defaults:
           run:
@@ -85,17 +85,12 @@ jobs:
               done
               exit 1
 
-          - name: Stage changes
-            working-directory: .
-            run: |
-              git pull --rebase --autostash
-              git add -A
-
           - name: Commit changes
             id: commit
-            uses: apify/workflows/commit@v0.44.0
+            uses: apify/actions/signed-commit@v1.0.0
             with:
-                commit-message: "chore(js-release): Update package version [skip ci]"
+                message: "chore(js-release): Update package version [skip ci]"
+                pull: '--rebase --autostash'
                 github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
           - name: Create version tag
@@ -103,7 +98,7 @@ jobs:
             env:
               GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
               TAG_NAME: "js-${{ steps.get-new-version.outputs.TARGET_VERSION }}"
-              COMMIT_SHA: ${{ steps.commit.outputs.commit-sha }}
+              COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
             run: |
               gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
                 -f ref="refs/tags/${TAG_NAME}" \
@@ -131,23 +126,13 @@ jobs:
             OUTPUT: impit-node/CHANGELOG.md
             GITHUB_REPO: ${{ github.repository }}
 
-        - name: Stage new changelog
-          id: stage_changelog
-          run: |
-            git pull --rebase --autostash
-            git add impit-node/CHANGELOG.md
-            if git diff --cached --quiet; then
-              echo "has-changes=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "has-changes=true" >> "$GITHUB_OUTPUT"
-            fi
-
         - name: Commit new changelog
           id: commit_changelog
-          if: steps.stage_changelog.outputs.has-changes == 'true'
-          uses: apify/workflows/commit@v0.44.0
+          uses: apify/actions/signed-commit@v1.0.0
           with:
-            commit-message: "docs: update changelog [skip ci]"
+            message: "docs: update changelog [skip ci]"
+            add: impit-node/CHANGELOG.md
+            pull: '--rebase --autostash'
             github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
         - name: Create release

--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -28,7 +28,7 @@ jobs:
 
     publish:
         outputs:
-          bumped-version-commit-sha: ${{ steps.commit.outputs.commit_sha || github.sha }}
+          bumped-version-commit-sha: ${{ steps.commit.outputs.commit_long_sha }}
           new_version: ${{ steps.get-new-version.outputs.TARGET_VERSION }}
         defaults:
           run:
@@ -98,7 +98,7 @@ jobs:
             env:
               GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
               TAG_NAME: "js-${{ steps.get-new-version.outputs.TARGET_VERSION }}"
-              COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
+              COMMIT_SHA: ${{ steps.commit.outputs.commit_long_sha }}
             run: |
               gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
                 -f ref="refs/tags/${TAG_NAME}" \

--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -87,7 +87,7 @@ jobs:
 
           - name: Commit changes
             id: commit
-            uses: apify/actions/signed-commit@v1.0.0
+            uses: apify/actions/signed-commit@v1.1.2
             with:
                 message: "chore(js-release): Update package version [skip ci]"
                 pull: '--rebase --autostash'
@@ -128,7 +128,7 @@ jobs:
 
         - name: Commit new changelog
           id: commit_changelog
-          uses: apify/actions/signed-commit@v1.0.0
+          uses: apify/actions/signed-commit@v1.1.2
           with:
             message: "docs: update changelog [skip ci]"
             add: impit-node/CHANGELOG.md

--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -28,7 +28,7 @@ jobs:
 
     publish:
         outputs:
-          bumped-version-commit-sha: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+          bumped-version-commit-sha: ${{ steps.commit.outputs.commit-sha || github.sha }}
           new_version: ${{ steps.get-new-version.outputs.TARGET_VERSION }}
         defaults:
           run:
@@ -85,15 +85,29 @@ jobs:
               done
               exit 1
 
+          - name: Stage changes
+            working-directory: .
+            run: |
+              git pull --rebase --autostash
+              git add -A
+
           - name: Commit changes
             id: commit
-            uses: EndBug/add-and-commit@v10
+            uses: apify/workflows/commit@v0.44.0
             with:
-                author_name: Apify Release Bot
-                author_email: noreply@apify.com
-                message: "chore(js-release): Update package version [skip ci]"
-                tag: "js-${{ steps.get-new-version.outputs.TARGET_VERSION }}"
-                pull: '--rebase --autostash'
+                commit-message: "chore(js-release): Update package version [skip ci]"
+                github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
+          - name: Create version tag
+            working-directory: .
+            env:
+              GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+              TAG_NAME: "js-${{ steps.get-new-version.outputs.TARGET_VERSION }}"
+              COMMIT_SHA: ${{ steps.commit.outputs.commit-sha }}
+            run: |
+              gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+                -f ref="refs/tags/${TAG_NAME}" \
+                -f sha="${COMMIT_SHA}"
 
     changelog:
       name: Generate changelog
@@ -117,15 +131,24 @@ jobs:
             OUTPUT: impit-node/CHANGELOG.md
             GITHUB_REPO: ${{ github.repository }}
 
+        - name: Stage new changelog
+          id: stage_changelog
+          run: |
+            git pull --rebase --autostash
+            git add impit-node/CHANGELOG.md
+            if git diff --cached --quiet; then
+              echo "has-changes=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "has-changes=true" >> "$GITHUB_OUTPUT"
+            fi
+
         - name: Commit new changelog
           id: commit_changelog
-          uses: EndBug/add-and-commit@v10
+          if: steps.stage_changelog.outputs.has-changes == 'true'
+          uses: apify/workflows/commit@v0.44.0
           with:
-            author_name: github-actions[bot]
-            author_email: github-actions[bot]@users.noreply.github.com
-            message: "docs: update changelog [skip ci]"
-            add: 'impit-node/CHANGELOG.md'
-            pull: '--rebase --autostash'
+            commit-message: "docs: update changelog [skip ci]"
+            github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
         - name: Create release
           uses: softprops/action-gh-release@v2

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -19,7 +19,7 @@ jobs:
     get_version:
       runs-on: ubuntu-latest
       outputs:
-        bumped-version-commit-sha: ${{ steps.commit_version.outputs.commit_sha }}
+        bumped-version-commit-sha: ${{ steps.commit_version.outputs.commit_long_sha }}
         new_version: ${{ steps.increment_version.outputs.new_version }}
       steps:
         - uses: actions/checkout@v6
@@ -69,7 +69,7 @@ jobs:
           env:
             GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
             TAG_NAME: "py-${{ steps.increment_version.outputs.new_version }}"
-            COMMIT_SHA: ${{ steps.commit_version.outputs.commit_sha }}
+            COMMIT_SHA: ${{ steps.commit_version.outputs.commit_long_sha }}
           run: |
             gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
               -f ref="refs/tags/${TAG_NAME}" \

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -19,7 +19,7 @@ jobs:
     get_version:
       runs-on: ubuntu-latest
       outputs:
-        bumped-version-commit-sha: ${{ steps.commit_version.outputs.commit_sha || github.sha }}
+        bumped-version-commit-sha: ${{ steps.commit_version.outputs.commit_sha }}
         new_version: ${{ steps.increment_version.outputs.new_version }}
       steps:
         - uses: actions/checkout@v6
@@ -123,7 +123,7 @@ jobs:
             token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
             ref: master
             fetch-depth: 0
-  
+
         - name: Generate a changelog
           uses: orhun/git-cliff-action@v4
           id: git-cliff

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -58,7 +58,7 @@ jobs:
 
         - name: Commit new version
           id: commit_version
-          uses: apify/actions/signed-commit@v1.0.0
+          uses: apify/actions/signed-commit@v1.1.2
           with:
             message: "chore(py-release): bump `pyproject.toml` version [skip ci]"
             add: impit-python/pyproject.toml
@@ -136,7 +136,7 @@ jobs:
 
         - name: Commit new changelog
           id: commit_changelog
-          uses: apify/actions/signed-commit@v1.0.0
+          uses: apify/actions/signed-commit@v1.1.2
           with:
             message: "docs: update changelog [skip ci]"
             add: impit-python/CHANGELOG.md

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -19,7 +19,7 @@ jobs:
     get_version:
       runs-on: ubuntu-latest
       outputs:
-        bumped-version-commit-sha: ${{ steps.commit_version.outputs.commit-sha || github.sha }}
+        bumped-version-commit-sha: ${{ steps.commit_version.outputs.commit_sha || github.sha }}
         new_version: ${{ steps.increment_version.outputs.new_version }}
       steps:
         - uses: actions/checkout@v6
@@ -56,23 +56,20 @@ jobs:
             echo "New version is ${{ steps.increment_version.outputs.new_version }}"
             uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version ${{ steps.increment_version.outputs.new_version }}
 
-        - name: Stage new version
-          run: |
-            git pull --rebase --autostash
-            git add impit-python/pyproject.toml
-
         - name: Commit new version
           id: commit_version
-          uses: apify/workflows/commit@v0.44.0
+          uses: apify/actions/signed-commit@v1.0.0
           with:
-            commit-message: "chore(py-release): bump `pyproject.toml` version [skip ci]"
+            message: "chore(py-release): bump `pyproject.toml` version [skip ci]"
+            add: impit-python/pyproject.toml
+            pull: '--rebase --autostash'
             github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
         - name: Create version tag
           env:
             GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
             TAG_NAME: "py-${{ steps.increment_version.outputs.new_version }}"
-            COMMIT_SHA: ${{ steps.commit_version.outputs.commit-sha }}
+            COMMIT_SHA: ${{ steps.commit_version.outputs.commit_sha }}
           run: |
             gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
               -f ref="refs/tags/${TAG_NAME}" \
@@ -137,23 +134,13 @@ jobs:
             OUTPUT: impit-python/CHANGELOG.md
             GITHUB_REPO: ${{ github.repository }}
 
-        - name: Stage new changelog
-          id: stage_changelog
-          run: |
-            git pull --rebase --autostash
-            git add impit-python/CHANGELOG.md
-            if git diff --cached --quiet; then
-              echo "has-changes=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "has-changes=true" >> "$GITHUB_OUTPUT"
-            fi
-
         - name: Commit new changelog
           id: commit_changelog
-          if: steps.stage_changelog.outputs.has-changes == 'true'
-          uses: apify/workflows/commit@v0.44.0
+          uses: apify/actions/signed-commit@v1.0.0
           with:
-            commit-message: "docs: update changelog [skip ci]"
+            message: "docs: update changelog [skip ci]"
+            add: impit-python/CHANGELOG.md
+            pull: '--rebase --autostash'
             github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
         - name: Create release

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -19,7 +19,7 @@ jobs:
     get_version:
       runs-on: ubuntu-latest
       outputs:
-        bumped-version-commit-sha: ${{ steps.commit_version.outputs.commit_long_sha || github.sha }}
+        bumped-version-commit-sha: ${{ steps.commit_version.outputs.commit-sha || github.sha }}
         new_version: ${{ steps.increment_version.outputs.new_version }}
       steps:
         - uses: actions/checkout@v6
@@ -56,16 +56,27 @@ jobs:
             echo "New version is ${{ steps.increment_version.outputs.new_version }}"
             uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version ${{ steps.increment_version.outputs.new_version }}
 
+        - name: Stage new version
+          run: |
+            git pull --rebase --autostash
+            git add impit-python/pyproject.toml
+
         - name: Commit new version
           id: commit_version
-          uses: EndBug/add-and-commit@v10
+          uses: apify/workflows/commit@v0.44.0
           with:
-            author_name: github-actions[bot]
-            author_email: github-actions[bot]@users.noreply.github.com
-            message: "chore(py-release): bump `pyproject.toml` version [skip ci]"
-            add: 'impit-python/pyproject.toml'
-            tag: "py-${{ steps.increment_version.outputs.new_version }}"
-            pull: '--rebase --autostash'
+            commit-message: "chore(py-release): bump `pyproject.toml` version [skip ci]"
+            github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
+        - name: Create version tag
+          env:
+            GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+            TAG_NAME: "py-${{ steps.increment_version.outputs.new_version }}"
+            COMMIT_SHA: ${{ steps.commit_version.outputs.commit-sha }}
+          run: |
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${TAG_NAME}" \
+              -f sha="${COMMIT_SHA}"
 
     test:
         needs: [get_version]
@@ -126,15 +137,24 @@ jobs:
             OUTPUT: impit-python/CHANGELOG.md
             GITHUB_REPO: ${{ github.repository }}
 
+        - name: Stage new changelog
+          id: stage_changelog
+          run: |
+            git pull --rebase --autostash
+            git add impit-python/CHANGELOG.md
+            if git diff --cached --quiet; then
+              echo "has-changes=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "has-changes=true" >> "$GITHUB_OUTPUT"
+            fi
+
         - name: Commit new changelog
           id: commit_changelog
-          uses: EndBug/add-and-commit@v10
+          if: steps.stage_changelog.outputs.has-changes == 'true'
+          uses: apify/workflows/commit@v0.44.0
           with:
-            author_name: github-actions[bot]
-            author_email: github-actions[bot]@users.noreply.github.com
-            message: "docs: update changelog [skip ci]"
-            add: 'impit-python/CHANGELOG.md'
-            pull: '--rebase --autostash'
+            commit-message: "docs: update changelog [skip ci]"
+            github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
         - name: Create release
           uses: softprops/action-gh-release@v2


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.