### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@main
+        uses: apify/actions/pnpm-install@v1.0.0
         with:
           working-directory: impit-node
 

--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -48,7 +48,7 @@ jobs:
               registry-url: 'https://registry.npmjs.org'
 
           - name: Install pnpm and dependencies
-            uses: apify/workflows/pnpm-install@main
+            uses: apify/actions/pnpm-install@v1.0.0
             with:
               working-directory: impit-node
 

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install pnpm and dependencies
         if: ${{ !matrix.settings.docker }}
-        uses: apify/workflows/pnpm-install@main
+        uses: apify/actions/pnpm-install@v1.0.0
         with:
           working-directory: impit-node
 
@@ -177,7 +177,7 @@ jobs:
           architecture: x64
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@main
+        uses: apify/actions/pnpm-install@v1.0.0
         with:
           working-directory: impit-node
 
@@ -214,7 +214,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@main
+        uses: apify/actions/pnpm-install@v1.0.0
         with:
           working-directory: impit-node
 
@@ -249,7 +249,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@main
+        uses: apify/actions/pnpm-install@v1.0.0
         with:
           working-directory: impit-node
 


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.