### PR TITLE
chore: Update actions from `apify/actions` [internal]

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
         with:
           working-directory: impit-node
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
         with:
           working-directory: impit-node
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
         with:
           working-directory: impit-node
 

--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -48,7 +48,7 @@ jobs:
               registry-url: 'https://registry.npmjs.org'
 
           - name: Install pnpm and dependencies
-            uses: apify/actions/pnpm-install@v1.1.1
+            uses: apify/actions/pnpm-install@v1.1.2
             with:
               working-directory: impit-node
 

--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -48,7 +48,7 @@ jobs:
               registry-url: 'https://registry.npmjs.org'
 
           - name: Install pnpm and dependencies
-            uses: apify/actions/pnpm-install@v1.1.0
+            uses: apify/actions/pnpm-install@v1.1.1
             with:
               working-directory: impit-node
 

--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -48,7 +48,7 @@ jobs:
               registry-url: 'https://registry.npmjs.org'
 
           - name: Install pnpm and dependencies
-            uses: apify/actions/pnpm-install@v1.0.0
+            uses: apify/actions/pnpm-install@v1.1.0
             with:
               working-directory: impit-node
 

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install pnpm and dependencies
         if: ${{ !matrix.settings.docker }}
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
         with:
           working-directory: impit-node
 
@@ -177,7 +177,7 @@ jobs:
           architecture: x64
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
         with:
           working-directory: impit-node
 
@@ -214,7 +214,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
         with:
           working-directory: impit-node
 
@@ -249,7 +249,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
         with:
           working-directory: impit-node
 

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install pnpm and dependencies
         if: ${{ !matrix.settings.docker }}
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
         with:
           working-directory: impit-node
 
@@ -177,7 +177,7 @@ jobs:
           architecture: x64
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
         with:
           working-directory: impit-node
 
@@ -214,7 +214,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
         with:
           working-directory: impit-node
 
@@ -249,7 +249,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
         with:
           working-directory: impit-node
 

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install pnpm and dependencies
         if: ${{ !matrix.settings.docker }}
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
         with:
           working-directory: impit-node
 
@@ -177,7 +177,7 @@ jobs:
           architecture: x64
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
         with:
           working-directory: impit-node
 
@@ -214,7 +214,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
         with:
           working-directory: impit-node
 
@@ -249,7 +249,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
         with:
           working-directory: impit-node
 


### PR DESCRIPTION
There was an issue with the `v1.0.0` version of some of the actions from `apify/actions` (a NPM dependency was not present), I've released an updated version which fixes it.