### PR TITLE
chore: Don't test bindings on Node.js 20 + Intel + macOS combination

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -167,6 +167,15 @@ jobs:
           - '20'
           - '22'
           - '24'
+        exclude:
+          # @pnpm/exe does not ship a working binary for Intel macOS (darwin-x64) due to an upstream Node.js SEA bug.
+          # See https://github.com/pnpm/pnpm/issues/11423 and https://github.com/nodejs/node/issues/62893.
+          # We just skip this combination, as Node 20 is EOL anyway,
+          # and we test the same target on Node 22+, so chances are that the bindings work on Node 20 as well.
+          - settings:
+              host: macos-latest
+              target: x86_64-apple-darwin
+            node: '20'
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Due to an upstream Node.js bug, which will not be fixed on Node 20 as it is EOL, PNPM does not ship a working binary for Intel macOS (see https://github.com/pnpm/pnpm/issues/11423 and https://github.com/nodejs/node/issues/62893), and the `setup-pnpm` step cannot run.

We've decided to just skip this combination in CI, as we believe the bindings should be sufficiently tested by all the other combinations.