### PR TITLE
chore: enforce min release age in uv and disable renovate for cargo

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Disable automatic `uv` builds
-        run: printf "\n[tool.uv]\npackage = false" >> pyproject.toml
+        run: sed -i '/^\[tool\.uv\]$/a package = false' pyproject.toml
         working-directory: impit-python
 
       - name: Install dependencies

--- a/.github/workflows/python-code-checks.yaml
+++ b/.github/workflows/python-code-checks.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
 
       - name: Disable automatic `uv` builds
-        run: printf "\n[tool.uv]\npackage = false" >> pyproject.toml
+        run: sed -i '/^\[tool\.uv\]$/a package = false' pyproject.toml
         working-directory: impit-python
 
       - name: Install Python dependencies
@@ -60,7 +60,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
 
       - name: Disable automatic `uv` builds
-        run: printf "\n[tool.uv]\npackage = false" >> pyproject.toml
+        run: sed -i '/^\[tool\.uv\]$/a package = false' pyproject.toml
         working-directory: impit-python
 
       - name: Install Python dependencies

--- a/impit-python/pyproject.toml
+++ b/impit-python/pyproject.toml
@@ -135,5 +135,8 @@ warn_unused_ignores = true
 module = ["pproxy"]
 ignore_missing_imports = true
 
+[tool.uv]
+exclude-newer = "1 day"
+
 [tool.uv.sources]
 stubdoc = { git = "https://github.com/bayashi-cl/stubdoc" }

--- a/impit-python/uv.lock
+++ b/impit-python/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1D"
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
 		"automerge": true,
 		"automergeType": "branch"
 	},
+	"cargo": {
+		"enabled": false
+	},
 	"packageRules": [
 		{
 			"matchUpdateTypes": ["patch", "minor"],


### PR DESCRIPTION
Adds `exclude-newer = "1 day"` to the python project's uv config, mirroring the `minimumReleaseAge: 1440` already enforced via pnpm in the node bindings. The lockfile gains an `[options]` block recording the constraint; no resolved versions change.

Cargo has no built-in equivalent to `minimumReleaseAge`, so the cargo manager is disabled in `renovate.json`. Renovate continues to apply the 1-day delay to npm and pypi updates as before. 

Cargo support for publish time-based constraints [is being actively developed](https://github.com/rust-lang/cargo/issues/17009) - once this lands, we can enable Renovate for Cargo as well.

Closes #451