### PR TITLE
ci: restrict GITHUB_TOKEN to contents:read in format and python-code-checks workflows

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -8,6 +8,9 @@ on:
 env:
   RUSTFLAGS: "--cfg reqwest_unstable"
 
+permissions:
+  contents: read
+
 jobs:
   fmt:
     name: rustfmt

--- a/.github/workflows/python-code-checks.yaml
+++ b/.github/workflows/python-code-checks.yaml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch: null
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint_check:
     name: Lint check


### PR DESCRIPTION
Closes CodeQL alerts #1, #3, #4 (format.yaml) and #5, #6 (python-code-checks.yaml) by adding a workflow-level `permissions: contents: read` block. Neither workflow needs anything beyond checkout.