### PR TITLE
chore(docs): make `typedoc` resolve node `Buffer` type via `tsconfig.docs.json`

### DIFF
--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -46,7 +46,7 @@
     "artifacts": "napi artifacts --output-dir ../artifacts --npm-dir npm",
     "build": "napi build --platform --release --no-const-enum",
     "build:debug": "napi build --platform --no-const-enum",
-    "docs": "pnpm build:debug && typedoc --plugin typedoc-plugin-mdn-links ./index.d.ts --out ./docs",
+    "docs": "pnpm build:debug && typedoc --plugin typedoc-plugin-mdn-links --tsconfig ./tsconfig.docs.json ./index.d.ts --out ./docs",
     "prepublishOnly": "napi prepublish -t npm --no-gh-release",
     "test": "vitest --retry=3 && node ./test/e2e/run-e2e-tests.mjs",
     "universal": "napi universal",

--- a/impit-node/tsconfig.docs.json
+++ b/impit-node/tsconfig.docs.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "files": ["index.d.ts"]
+}


### PR DESCRIPTION
The docs build started failing on master after the TypeScript v6 upgrade (#425) with:

```
index.d.ts:147:24 - error TS2591: Cannot find name 'Buffer'.
```

TS6 no longer accepts an unresolved `Buffer` global. The `docs` script ran typedoc without a tsconfig, so `@types/node` (already a devDependency) was not picked up.

Adds a minimal `impit-node/tsconfig.docs.json` that pins `types: ["node"]` and scopes the program to `index.d.ts`, and passes it to typedoc via `--tsconfig`. Verified locally — docs now generate without error.