### PR TITLE
fix: drop only-allow preinstall from the published package

### DIFF
--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -50,8 +50,7 @@
     "prepublishOnly": "napi prepublish -t npm --no-gh-release",
     "test": "vitest --retry=3 && node ./test/e2e/run-e2e-tests.mjs",
     "universal": "napi universal",
-    "copy-version": "napi version",
-    "preinstall": "npx only-allow pnpm"
+    "copy-version": "napi version"
   },
   "packageManager": "pnpm@10.24.0",
   "description": "Impit for JavaScript",


### PR DESCRIPTION
`preinstall: npx only-allow pnpm` in `impit-node/package.json` is a contributor guard, but it's published in the `impit` package, so it runs on **every consumer install**. It forces a network `npx only-allow` fetch during install, which breaks downstream installs whenever that fetch flakes (corrupted npm cache / ENOENT) — e.g. it intermittently fails `yarn install` in apify/crawlee CI.

impit ships prebuilt native binaries (`optionalDependencies: impit-*`), so consumers need no install/build scripts. Removing the published `preinstall` fixes it for all downstreams.

If the pnpm guard is still wanted for local development, it belongs at the (non-published) repo root rather than inside the published `impit-node` package.