### PR TITLE
chore(js): restore missing `impit-linux-arm64-musl` in lockfile

### DIFF
--- a/impit-node/pnpm-lock.yaml
+++ b/impit-node/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       impit-linux-arm64-gnu:
         specifier: 0.14.1
         version: 0.14.1
+      impit-linux-arm64-musl:
+        specifier: 0.14.1
+        version: 0.14.1
       impit-linux-x64-gnu:
         specifier: 0.14.1
         version: 0.14.1
@@ -1068,6 +1071,13 @@ packages:
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
+
+  impit-linux-arm64-musl@0.14.1:
+    resolution: {integrity: sha512-lFatihYntVIN814AnoNm/hSw5iONLKt6XtaAaJahZNdJOU+zsclcg9pbK0/61aENamkpIBpok/H8j5Sw/Xjuuw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   impit-linux-x64-gnu@0.14.1:
     resolution: {integrity: sha512-oioVQzHqSi68BzxRpVLbNv9HRgOxAA21QNlzCMyeEM3/c02MkURCQ1W66yAlEFOR1gaqPZDJi/ymnmIGk6+PjQ==}
@@ -2447,6 +2457,9 @@ snapshots:
     optional: true
 
   impit-linux-arm64-gnu@0.14.1:
+    optional: true
+
+  impit-linux-arm64-musl@0.14.1:
     optional: true
 
   impit-linux-x64-gnu@0.14.1:


### PR DESCRIPTION
The 0.14.1 release commit (05e4ad7) bumped all eight platform packages in `package.json` to `0.14.1`, but `pnpm-lock.yaml` ended up missing `impit-linux-arm64-musl` entirely instead of bumping it. This leaves the lockfile out of sync with `package.json`, so every `pnpm install --frozen-lockfile` in CI fails with `ERR_PNPM_OUTDATED_LOCKFILE`.

The package itself published fine — the lockfile was regenerated by the release workflow ~12s after `impit-linux-arm64-musl@0.14.1` was published, before the npm registry had propagated it. Since these are optional dependencies, pnpm silently omitted the one it couldn't resolve and still exited 0, so the incomplete lockfile got committed.

This regenerates the lockfile now that the package has propagated, restoring the missing entry. `pnpm install --frozen-lockfile` passes locally. The workflow change to prevent recurrence is in a follow-up PR.