### PR TITLE
chore(ci): validate regenerated lockfile during `impit-`node release

### DIFF
--- a/.github/workflows/node-release.yaml
+++ b/.github/workflows/node-release.yaml
@@ -80,8 +80,8 @@ jobs:
           - name: Update lockfile
             run: |
               for i in $(seq 1 5); do
-                pnpm install --lockfile-only && exit 0
-                [ $i -lt 5 ] && echo "Attempt $i failed, waiting 30s before retry..." && sleep 30
+                pnpm install --lockfile-only && pnpm install --frozen-lockfile && exit 0
+                [ $i -lt 5 ] && echo "Attempt $i failed (lockfile out of sync, likely registry propagation lag), waiting 30s before retry..." && sleep 30
               done
               exit 1
 


### PR DESCRIPTION
Follow-up to #467, which fixed the symptom. This fixes the root cause in the release workflow.

The `Update lockfile` step runs `pnpm install --lockfile-only` after publishing. That command exits 0 even when an optional dependency can't be resolved — it just silently drops it from the lockfile. Because the regeneration runs seconds after `pnpm publish`, a freshly published platform package may not have propagated on the npm registry yet, so it gets omitted while the retry loop's exit-code check still passes. That is exactly how the `impit-linux-arm64-musl` entry went missing in the 0.14.1 release.

This chains a `pnpm install --frozen-lockfile` after the regeneration. The loop now only exits 0 once the regenerated lockfile actually matches `package.json` (the same check CI runs); if an optional dep was dropped, the frozen install fails and the loop retries after 30s until the registry catches up.