### PR TITLE
fix(python): raise on mid-stream body errors instead of silent EOF

### DIFF
--- a/impit-python/src/response.rs
+++ b/impit-python/src/response.rs
@@ -63,12 +63,11 @@ impl PyResponseBytesIterator {
                     if let Some(parent) = &slf.parent_response {
                         if let Ok(mut parent_ref) = parent.try_borrow_mut(py) {
                             parent_ref.inner_state = InnerResponseState::StreamingClosed;
+                            parent_ref.is_stream_consumed = true;
                             parent_ref.is_closed = true;
                         }
                     }
-                    Err(pyo3::exceptions::PyStopIteration::new_err(format!(
-                        "Stream error: {e}"
-                    )))
+                    Err(ImpitPyError(ImpitError::from(e, None)).into())
                 }
                 None => {
                     slf.content_returned = true;
@@ -155,13 +154,12 @@ impl PyResponseAsyncBytesIterator {
                         Python::attach(|py| {
                             if let Ok(mut parent_ref) = parent.try_borrow_mut(py) {
                                 parent_ref.inner_state = InnerResponseState::StreamingClosed;
+                                parent_ref.is_stream_consumed = true;
                                 parent_ref.is_closed = true;
                             }
                         });
                     }
-                    Err(pyo3::exceptions::PyStopAsyncIteration::new_err(format!(
-                        "Stream error: {e}"
-                    )))
+                    Err(ImpitPyError(ImpitError::from(e, None)).into())
                 }
                 None => {
                     if let Some(parent) = parent_response {

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import pytest
 
-from impit import AsyncClient, Browser, Cookies, StreamClosed, StreamConsumed, TooManyRedirects
+from impit import AsyncClient, Browser, Cookies, RemoteProtocolError, StreamClosed, StreamConsumed, TooManyRedirects
 
 from .httpbin import get_httpbin_url
 from .setup_proxy import start_proxy_server
@@ -26,6 +26,22 @@ def thread_server(port_holder: list[int]) -> None:
     client_ip, *_ = addr
     response = f'HTTP/1.1 200 OK\r\nContent-Length: {len(client_ip)}\r\n\r\n{client_ip}'.encode()
     conn.send(response)
+    conn.close()
+    server.close()
+
+
+def truncating_server(port_holder: list[int]) -> None:
+    """Announce a `Content-Length` larger than the body actually sent, then close the socket mid-body."""
+    server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    server.bind(('::', 0))
+    port_holder[0] = server.getsockname()[1]
+    server.listen(1)
+
+    conn, _ = server.accept()
+    conn.recv(1024)
+    conn.send(b'HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n0123456789')
     conn.close()
     server.close()
 
@@ -638,3 +654,19 @@ class TestStreamRequest:
 
         with pytest.raises(StreamClosed):
             _ = response.content
+
+    async def test_truncated_stream_raises(self, browser: Browser) -> None:
+        port_holder = [0]
+        thread = threading.Thread(target=truncating_server, args=(port_holder,))
+        thread.start()
+        await asyncio.sleep(0.1)
+
+        impit = AsyncClient(browser=browser)
+
+        async with impit.stream('GET', f'http://localhost:{port_holder[0]}/', timeout=5) as response:
+            assert response.status_code == 200
+
+            with pytest.raises(RemoteProtocolError):
+                _ = b''.join([item async for item in response.aiter_bytes()])
+
+        thread.join()

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -14,6 +14,7 @@ from impit import (
     ConnectTimeout,
     Cookies,
     ReadTimeout,
+    RemoteProtocolError,
     StreamClosed,
     StreamConsumed,
     TimeoutException,
@@ -37,6 +38,22 @@ def thread_server(port_holder: list[int]) -> None:
     client_ip, *_ = addr
     response = f'HTTP/1.1 200 OK\r\nContent-Length: {len(client_ip)}\r\n\r\n{client_ip}'.encode()
     conn.send(response)
+    conn.close()
+    server.close()
+
+
+def truncating_server(port_holder: list[int]) -> None:
+    """Announce a `Content-Length` larger than the body actually sent, then close the socket mid-body."""
+    server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    server.bind(('::', 0))
+    port_holder[0] = server.getsockname()[1]
+    server.listen(1)
+
+    conn, _ = server.accept()
+    conn.recv(1024)
+    conn.send(b'HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n0123456789')
     conn.close()
     server.close()
 
@@ -610,6 +627,22 @@ class TestStreamRequest:
 
         with pytest.raises(StreamClosed):
             _ = response.content
+
+    def test_truncated_stream_raises(self, browser: Browser) -> None:
+        port_holder = [0]
+        thread = threading.Thread(target=truncating_server, args=(port_holder,))
+        thread.start()
+        time.sleep(0.1)
+
+        impit = Client(browser=browser)
+
+        with impit.stream('GET', f'http://localhost:{port_holder[0]}/', timeout=5) as response:
+            assert response.status_code == 200
+
+            with pytest.raises(RemoteProtocolError):
+                _ = b''.join(response.iter_bytes())
+
+        thread.join()
 
 
 def make_slow_server(port_holder: list[int], delay: float = 2.0) -> None:

--- a/impit/src/errors.rs
+++ b/impit/src/errors.rs
@@ -122,7 +122,9 @@ impl ImpitError {
             return ImpitError::TooManyRedirects(context.max_redirects);
         }
 
-        if error.is_body() && (format!("{:?}", error).to_lowercase()).contains("unexpectedeof") {
+        if (error.is_body() || error.is_decode())
+            && (format!("{:?}", error).to_lowercase()).contains("unexpectedeof")
+        {
             return ImpitError::RemoteProtocolError;
         }
 


### PR DESCRIPTION
Mid-stream body errors (connection reset, truncated chunked transfer) were mapped to `StopIteration`/`StopAsyncIteration`, which signal normal end-of-iteration — so `for`/`async for` ended silently and callers processed partial bodies as complete (a silent data-integrity bug, [#475](https://github.com/apify/impit/issues/475)). Both sync and async iterators now propagate the classified `ImpitError` as a real exception and set the consumed/closed flags consistently with the clean-EOF branch.

Streamed truncation surfaces in reqwest as a `Decode`-kinded error rather than `Body`, so the existing unexpected-EOF classification missed it and fell through to the catch-all `HTTPError`. The guard is widened to cover `is_decode()`, so truncated streams now raise `RemoteProtocolError`, matching httpx.

Verified against a vanilla server that truncates the body mid-response; added sync + async regression tests.

Closes #475