### PR TITLE
fix(node): encode string chunks when serializing stream bodies

### DIFF
--- a/impit-node/index.wrapper.js
+++ b/impit-node/index.wrapper.js
@@ -43,6 +43,23 @@ function isRedirectStatus(status) {
     return [301, 302, 303, 307, 308].includes(status);
 }
 
+// Stream chunks may be strings (e.g. a ReadableStream or Node stream that wasn't
+// fed bytes); encode them so they aren't coerced to zero bytes by Uint8Array.set.
+function toUint8Array(chunk) {
+    return typeof chunk === 'string' ? new TextEncoder().encode(chunk) : new Uint8Array(chunk);
+}
+
+function concatUint8Arrays(chunks) {
+    const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+        result.set(chunk, offset);
+        offset += chunk.length;
+    }
+    return result;
+}
+
 function shouldRewriteRedirectToGet(httpStatus, method) {
     // See https://github.com/mozilla-firefox/firefox/blob/911b3eec6c5e58a9a49e23aa105e49aa76e00f9c/netwerk/protocol/http/HttpBaseChannel.cpp#L4801
     if ([301, 302].includes(httpStatus)) {
@@ -183,16 +200,16 @@ class Impit extends native.Impit {
             while (!done) {
                 const { done: streamDone, value } = await reader.read();
                 done = streamDone;
-                if (value) chunks.push(value);
+                if (value != null) chunks.push(toUint8Array(value));
             }
-            const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
-            const typedArray = new Uint8Array(totalLength);
-            let offset = 0;
-            for (const chunk of chunks) {
-                typedArray.set(chunk, offset);
-                offset += chunk.length;
+            return { body: concatUint8Arrays(chunks), type: '' };
+        } else if (body && typeof body[Symbol.asyncIterator] === 'function') {
+            // Node.js streams (e.g. Readable.from(...)) and other async iterables.
+            const chunks = [];
+            for await (const chunk of body) {
+                chunks.push(toUint8Array(chunk));
             }
-            return { body: typedArray, type: '' };
+            return { body: concatUint8Arrays(chunks), type: '' };
         }
         return { body, type: '' };
     }

--- a/impit-node/test/basics.test.ts
+++ b/impit-node/test/basics.test.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { Readable } from 'node:stream';
 import { test, describe, expect, beforeAll, afterAll } from 'vitest';
 
 import { HttpMethod, Impit, Browser } from '../index.wrapper.js';
@@ -471,6 +472,68 @@ describe.each([
                 body: 'foo'
             });
             await expect(response).resolves.toBeTruthy();
+        });
+
+        const localPostUrl = 'http://localhost:3001/post';
+        const streamingTypes = ['ReadableStream', 'Readable'];
+        test.each([
+            ['string', () => STRING_PAYLOAD],
+            ['Blob', () => new Blob([STRING_PAYLOAD], { type: 'application/json' })],
+            ['URLSearchParams', () => new URLSearchParams(JSON.parse(STRING_PAYLOAD))],
+            ['FormData', () => { const form = new FormData(); form.append('Impit-Test', 'foořžš'); return form; }],
+            ['ReadableStream', () => new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode(STRING_PAYLOAD)); controller.close(); } })],
+            ['Readable', () => Readable.from(STRING_PAYLOAD)],
+        ])('passing Request with %s body', async (type, makeBody) => {
+            const request = new Request(localPostUrl, {
+                method: 'POST',
+                body: makeBody() as BodyInit,
+                ...(streamingTypes.includes(type) ? { duplex: 'half' } : {}),
+            } as RequestInit);
+
+            const response = await impit.fetch(request);
+            const json = await response.json();
+
+            if (type === 'URLSearchParams' || type === 'FormData') {
+                expect(json.form).toEqual(JSON.parse(STRING_PAYLOAD));
+            } else {
+                expect(json.data).toEqual(STRING_PAYLOAD);
+            }
+        });
+
+        test('passing a Node Readable stream as body', async () => {
+            const response = await impit.fetch(localPostUrl, {
+                method: HttpMethod.Post,
+                body: Readable.from(STRING_PAYLOAD) as any,
+            });
+            const json = await response.json();
+
+            expect(json.data).toEqual(STRING_PAYLOAD);
+        });
+
+        // https://github.com/apify/impit/issues/486
+        test('passing a ReadableStream that yields string chunks', async () => {
+            const stream = new ReadableStream({
+                start(controller) { controller.enqueue(STRING_PAYLOAD); controller.close(); },
+            });
+
+            const response = await impit.fetch(localPostUrl, { method: HttpMethod.Post, body: stream });
+            const json = await response.json();
+
+            expect(json.data).toEqual(STRING_PAYLOAD);
+        });
+
+        test('Request with body preserves its Content-Type', async () => {
+            const request = new Request(localPostUrl, {
+                method: 'POST',
+                body: STRING_PAYLOAD,
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            const response = await impit.fetch(request);
+            const json = await response.json();
+
+            expect(json.headers?.['content-type']).toBe('application/json');
+            expect(json.data).toEqual(STRING_PAYLOAD);
         });
     });
 

--- a/impit-node/test/mock.server.ts
+++ b/impit-node/test/mock.server.ts
@@ -26,8 +26,56 @@ export const routes = {
     },
 }
 
+function parseMultipart(body: Buffer, boundary: string): Record<string, string> {
+    const form: Record<string, string> = {};
+    const delimiter = Buffer.from(`--${boundary}`);
+    const separator = Buffer.from('\r\n\r\n');
+
+    let start = body.indexOf(delimiter);
+    while (start !== -1) {
+        start += delimiter.length;
+        const next = body.indexOf(delimiter, start);
+        if (next === -1) break;
+
+        const part = body.subarray(start, next);
+        const headerEnd = part.indexOf(separator);
+        if (headerEnd !== -1) {
+            const headerText = part.subarray(0, headerEnd).toString('utf8');
+            const nameMatch = headerText.match(/name="([^"]+)"/);
+            if (nameMatch) {
+                // Strip the trailing CRLF that precedes the next boundary.
+                const value = part.subarray(headerEnd + separator.length, part.length - 2).toString('utf8');
+                form[nameMatch[1]] = value;
+            }
+        }
+        start = next;
+    }
+
+    return form;
+}
+
 export async function runServer(port: number): Promise<Server> {
     const app = express();
+
+    // httpbin-like echo endpoint, so body tests don't depend on an external service.
+    app.all('/post', express.raw({ type: () => true, limit: '10mb' }), (req, res) => {
+        const body: Buffer = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0);
+        const contentType = req.headers['content-type'] ?? '';
+
+        let form: Record<string, string> | undefined;
+        if (contentType.includes('application/x-www-form-urlencoded')) {
+            form = Object.fromEntries(new URLSearchParams(body.toString('utf8')));
+        } else if (contentType.includes('multipart/form-data')) {
+            const boundary = contentType.match(/boundary=(.+)$/)?.[1];
+            if (boundary) form = parseMultipart(body, boundary);
+        }
+
+        res.json({
+            data: form ? '' : body.toString('utf8'),
+            form: form ?? {},
+            headers: req.headers,
+        });
+    });
 
     app.get(routes.charset.path, (req, res) => {
         res.set('Content-Type', 'text/plain; charset=windows-1250');


### PR DESCRIPTION
Fixes #486.

A request body backed by a `ReadableStream` that yields string chunks was copied into a `Uint8Array` via `set()`. Since `set()` coerces each character to `NaN` → `0`, the body went out with a correct `Content-Length` but filled entirely with zero bytes. This surfaced downstream in Crawlee as a POST going out as `content-length: 58` followed by 58 `0x00` bytes.