### PR TITLE
fix: Fix panic on a malformed server cookie

### DIFF
--- a/impit-python/src/cookies.rs
+++ b/impit-python/src/cookies.rs
@@ -91,13 +91,7 @@ impl CookieStore for PythonCookieJar {
 
                 kwargs.set_item("rest", rest).unwrap_or_default();
 
-                // A hostile or buggy server can send a `Set-Cookie` that
-                // `http.cookiejar.Cookie` rejects (e.g. a bad domain/expiry), and a custom
-                // cookie jar's `set_cookie` may raise too. Skip the offending cookie instead
-                // of `.unwrap()`ing: a panic here would unwind across the FFI boundary and
-                // abort the host process rather than raise a catchable Python exception.
-                // Cookie parsing errors are ignored silently, matching the Node binding's
-                // `setCookie` handling in `index.wrapper.js`.
+                // Cookie parsing errors are ignored silently.
                 let py_cookie = match self.cookie_constructor.call(py, (), Some(&kwargs)) {
                     Ok(py_cookie) => py_cookie,
                     Err(_) => continue,

--- a/impit-python/src/cookies.rs
+++ b/impit-python/src/cookies.rs
@@ -91,13 +91,30 @@ impl CookieStore for PythonCookieJar {
 
                 kwargs.set_item("rest", rest).unwrap_or_default();
 
-                let py_cookie = self.cookie_constructor.call(py, (), Some(&kwargs)).unwrap();
+                // A hostile or buggy server can send a `Set-Cookie` that
+                // `http.cookiejar.Cookie` rejects (e.g. a bad domain/expiry), and a custom
+                // cookie jar's `set_cookie` may raise too. Skip the offending cookie and warn
+                // instead of `.unwrap()`ing: a panic here would unwind across the FFI boundary
+                // and abort the host process rather than raise a catchable Python exception.
+                let py_cookie = match self.cookie_constructor.call(py, (), Some(&kwargs)) {
+                    Ok(py_cookie) => py_cookie,
+                    Err(err) => {
+                        warn_skipped_cookie(py, cookie.name(), &err);
+                        continue;
+                    }
+                };
 
-                let args = PyTuple::new(py, vec![py_cookie]).unwrap();
+                let args = match PyTuple::new(py, vec![py_cookie]) {
+                    Ok(args) => args,
+                    Err(err) => {
+                        warn_skipped_cookie(py, cookie.name(), &err);
+                        continue;
+                    }
+                };
 
-                self.cookie_jar
-                    .call_method1(py, "set_cookie", args)
-                    .unwrap();
+                if let Err(err) = self.cookie_jar.call_method1(py, "set_cookie", args) {
+                    warn_skipped_cookie(py, cookie.name(), &err);
+                }
             }
         });
     }
@@ -172,6 +189,21 @@ impl CookieStore for PythonCookieJar {
                 .parse::<reqwest::header::HeaderValue>()
                 .ok()
         })
+    }
+}
+
+/// Emits a Python `UserWarning` that a `Set-Cookie` was skipped because the cookie jar
+/// rejected it, instead of letting the error panic across the FFI boundary.
+fn warn_skipped_cookie(py: Python<'_>, cookie_name: &str, err: &PyErr) {
+    let message = format!("Skipping malformed cookie {cookie_name:?}: {err}");
+
+    let warned = PyModule::import(py, "warnings")
+        .and_then(|warnings| warnings.call_method1("warn", (message.as_str(),)));
+
+    // Fall back to stderr if even emitting the warning fails, so the cookie is never
+    // silently dropped and we still avoid aborting the process.
+    if warned.is_err() {
+        eprintln!("{message}");
     }
 }
 

--- a/impit-python/src/cookies.rs
+++ b/impit-python/src/cookies.rs
@@ -91,7 +91,7 @@ impl CookieStore for PythonCookieJar {
 
                 kwargs.set_item("rest", rest).unwrap_or_default();
 
-                // Cookie parsing errors are ignored silently.
+                // Malformed cookies and cookie-jar insertion errors are ignored silently.
                 let py_cookie = match self.cookie_constructor.call(py, (), Some(&kwargs)) {
                     Ok(py_cookie) => py_cookie,
                     Err(_) => continue,

--- a/impit-python/src/cookies.rs
+++ b/impit-python/src/cookies.rs
@@ -93,28 +93,22 @@ impl CookieStore for PythonCookieJar {
 
                 // A hostile or buggy server can send a `Set-Cookie` that
                 // `http.cookiejar.Cookie` rejects (e.g. a bad domain/expiry), and a custom
-                // cookie jar's `set_cookie` may raise too. Skip the offending cookie and warn
-                // instead of `.unwrap()`ing: a panic here would unwind across the FFI boundary
-                // and abort the host process rather than raise a catchable Python exception.
+                // cookie jar's `set_cookie` may raise too. Skip the offending cookie instead
+                // of `.unwrap()`ing: a panic here would unwind across the FFI boundary and
+                // abort the host process rather than raise a catchable Python exception.
+                // Cookie parsing errors are ignored silently, matching the Node binding's
+                // `setCookie` handling in `index.wrapper.js`.
                 let py_cookie = match self.cookie_constructor.call(py, (), Some(&kwargs)) {
                     Ok(py_cookie) => py_cookie,
-                    Err(err) => {
-                        warn_skipped_cookie(py, cookie.name(), &err);
-                        continue;
-                    }
+                    Err(_) => continue,
                 };
 
                 let args = match PyTuple::new(py, vec![py_cookie]) {
                     Ok(args) => args,
-                    Err(err) => {
-                        warn_skipped_cookie(py, cookie.name(), &err);
-                        continue;
-                    }
+                    Err(_) => continue,
                 };
 
-                if let Err(err) = self.cookie_jar.call_method1(py, "set_cookie", args) {
-                    warn_skipped_cookie(py, cookie.name(), &err);
-                }
+                let _ = self.cookie_jar.call_method1(py, "set_cookie", args);
             }
         });
     }
@@ -189,21 +183,6 @@ impl CookieStore for PythonCookieJar {
                 .parse::<reqwest::header::HeaderValue>()
                 .ok()
         })
-    }
-}
-
-/// Emits a Python `UserWarning` that a `Set-Cookie` was skipped because the cookie jar
-/// rejected it, instead of letting the error panic across the FFI boundary.
-fn warn_skipped_cookie(py: Python<'_>, cookie_name: &str, err: &PyErr) {
-    let message = format!("Skipping malformed cookie {cookie_name:?}: {err}");
-
-    let warned = PyModule::import(py, "warnings")
-        .and_then(|warnings| warnings.call_method1("warn", (message.as_str(),)));
-
-    // Fall back to stderr if even emitting the warning fails, so the cookie is never
-    // silently dropped and we still avoid aborting the process.
-    if warned.is_err() {
-        eprintln!("{message}");
     }
 }
 

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -194,7 +194,7 @@ class TestBasicRequests:
 
     @pytest.mark.asyncio
     async def test_rejected_cookie_is_skipped_not_crashing(self, browser: Browser) -> None:
-        """A cookie jar rejects are skipped instead of aborting the process."""
+        """Cookies rejected by the cookie jar are skipped instead of aborting the process."""
 
         class RejectingCookieJar(CookieJar):
             def set_cookie(self, cookie: Cookie) -> None:

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import socket
 import threading
-from http.cookiejar import CookieJar
+from http.cookiejar import Cookie, CookieJar
 from typing import Literal
 
 import pytest
@@ -191,6 +191,45 @@ class TestBasicRequests:
                 # Crate cookies, ignores the starting dot in the domain
                 # but it's ok - https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3
                 assert cookie.domain == '127.0.0.1'
+
+    @pytest.mark.asyncio
+    async def test_malformed_cookie_is_skipped_not_crashing(self, browser: Browser) -> None:
+        """A cookie the jar rejects is skipped instead of aborting the process.
+
+        Regression test for https://github.com/apify/impit/issues/478: `set_cookies`
+        runs inside reqwest's cookie-store callback, so a raising `set_cookie` used to
+        `.unwrap()` into a Rust panic that unwound across the FFI boundary and aborted
+        the host process. It must now be caught and the offending cookie skipped, while
+        valid cookies in the same response are still stored.
+        """
+
+        class RejectingCookieJar(CookieJar):
+            def set_cookie(self, cookie: Cookie) -> None:
+                if cookie.name == 'bad':
+                    raise ValueError('cookie jar rejects this cookie')
+                super().set_cookie(cookie)
+
+        cookies_jar = RejectingCookieJar()
+
+        impit = AsyncClient(browser=browser, cookie_jar=cookies_jar, follow_redirects=True)
+
+        url = get_httpbin_url(
+            '/response-headers',
+            query={
+                'set-cookie': [
+                    'bad=1; Path=/',
+                    'good=2; Path=/',
+                ]
+            },
+        )
+
+        # The request must return normally rather than aborting the interpreter.
+        response = await impit.get(url)
+        assert response.status_code == 200
+
+        names = {cookie.name for cookie in cookies_jar}
+        assert 'bad' not in names  # the rejected cookie was skipped
+        assert 'good' in names  # a valid cookie in the same response is still stored
 
     @pytest.mark.asyncio
     async def test_cookie_jar_works(self, browser: Browser) -> None:

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -193,20 +193,13 @@ class TestBasicRequests:
                 assert cookie.domain == '127.0.0.1'
 
     @pytest.mark.asyncio
-    async def test_malformed_cookie_is_skipped_not_crashing(self, browser: Browser) -> None:
-        """A cookie the jar rejects is skipped instead of aborting the process.
-
-        Regression test for https://github.com/apify/impit/issues/478: `set_cookies`
-        runs inside reqwest's cookie-store callback, so a raising `set_cookie` used to
-        `.unwrap()` into a Rust panic that unwound across the FFI boundary and aborted
-        the host process. It must now be caught and the offending cookie skipped, while
-        valid cookies in the same response are still stored.
-        """
+    async def test_rejected_cookie_is_skipped_not_crashing(self, browser: Browser) -> None:
+        """A cookie jar rejects are skipped instead of aborting the process."""
 
         class RejectingCookieJar(CookieJar):
             def set_cookie(self, cookie: Cookie) -> None:
                 if cookie.name == 'bad':
-                    raise ValueError('cookie jar rejects this cookie')
+                    raise ValueError('simulate parsing error')
                 super().set_cookie(cookie)
 
         cookies_jar = RejectingCookieJar()
@@ -223,13 +216,10 @@ class TestBasicRequests:
             },
         )
 
-        # The request must return normally rather than aborting the interpreter.
         response = await impit.get(url)
         assert response.status_code == 200
 
-        names = {cookie.name for cookie in cookies_jar}
-        assert 'bad' not in names  # the rejected cookie was skipped
-        assert 'good' in names  # a valid cookie in the same response is still stored
+        assert {'good'} == {cookie.name for cookie in cookies_jar}
 
     @pytest.mark.asyncio
     async def test_cookie_jar_works(self, browser: Browser) -> None:

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -2,7 +2,7 @@ import json
 import socket
 import threading
 import time
-from http.cookiejar import CookieJar
+from http.cookiejar import Cookie, CookieJar
 from typing import Literal
 
 import pytest
@@ -202,6 +202,44 @@ class TestBasicRequests:
                 # Crate cookies, ignores the starting dot in the domain
                 # but it's ok - https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3
                 assert cookie.domain == '127.0.0.1'
+
+    def test_malformed_cookie_is_skipped_not_crashing(self, browser: Browser) -> None:
+        """A cookie the jar rejects is skipped instead of aborting the process.
+
+        Regression test for https://github.com/apify/impit/issues/478: `set_cookies`
+        runs inside reqwest's cookie-store callback, so a raising `set_cookie` used to
+        `.unwrap()` into a Rust panic that unwound across the FFI boundary and aborted
+        the host process. It must now be caught and the offending cookie skipped, while
+        valid cookies in the same response are still stored.
+        """
+
+        class RejectingCookieJar(CookieJar):
+            def set_cookie(self, cookie: Cookie) -> None:
+                if cookie.name == 'bad':
+                    raise ValueError('cookie jar rejects this cookie')
+                super().set_cookie(cookie)
+
+        cookies_jar = RejectingCookieJar()
+
+        impit = Client(browser=browser, cookie_jar=cookies_jar, follow_redirects=True)
+
+        url = get_httpbin_url(
+            '/response-headers',
+            query={
+                'set-cookie': [
+                    'bad=1; Path=/',
+                    'good=2; Path=/',
+                ]
+            },
+        )
+
+        # The request must return normally rather than aborting the interpreter.
+        response = impit.get(url)
+        assert response.status_code == 200
+
+        names = {cookie.name for cookie in cookies_jar}
+        assert 'bad' not in names  # the rejected cookie was skipped
+        assert 'good' in names  # a valid cookie in the same response is still stored
 
     def test_cookie_jar_works(self, browser: Browser) -> None:
         cookies = Cookies({'preset-cookie': '123'})

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -203,20 +203,13 @@ class TestBasicRequests:
                 # but it's ok - https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3
                 assert cookie.domain == '127.0.0.1'
 
-    def test_malformed_cookie_is_skipped_not_crashing(self, browser: Browser) -> None:
-        """A cookie the jar rejects is skipped instead of aborting the process.
-
-        Regression test for https://github.com/apify/impit/issues/478: `set_cookies`
-        runs inside reqwest's cookie-store callback, so a raising `set_cookie` used to
-        `.unwrap()` into a Rust panic that unwound across the FFI boundary and aborted
-        the host process. It must now be caught and the offending cookie skipped, while
-        valid cookies in the same response are still stored.
-        """
+    def test_rejected_cookie_is_skipped_not_crashing(self, browser: Browser) -> None:
+        """A cookie jar rejects are skipped instead of aborting the process."""
 
         class RejectingCookieJar(CookieJar):
             def set_cookie(self, cookie: Cookie) -> None:
                 if cookie.name == 'bad':
-                    raise ValueError('cookie jar rejects this cookie')
+                    raise ValueError('simulate parsing error')
                 super().set_cookie(cookie)
 
         cookies_jar = RejectingCookieJar()
@@ -233,13 +226,10 @@ class TestBasicRequests:
             },
         )
 
-        # The request must return normally rather than aborting the interpreter.
         response = impit.get(url)
         assert response.status_code == 200
 
-        names = {cookie.name for cookie in cookies_jar}
-        assert 'bad' not in names  # the rejected cookie was skipped
-        assert 'good' in names  # a valid cookie in the same response is still stored
+        assert {'good'} == {cookie.name for cookie in cookies_jar}
 
     def test_cookie_jar_works(self, browser: Browser) -> None:
         cookies = Cookies({'preset-cookie': '123'})

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -204,7 +204,7 @@ class TestBasicRequests:
                 assert cookie.domain == '127.0.0.1'
 
     def test_rejected_cookie_is_skipped_not_crashing(self, browser: Browser) -> None:
-        """A cookie jar rejects are skipped instead of aborting the process."""
+        """Cookies rejected by the cookie jar are skipped instead of aborting the process."""
 
         class RejectingCookieJar(CookieJar):
             def set_cookie(self, cookie: Cookie) -> None:

--- a/impit-python/uv.lock
+++ b/impit-python/uv.lock
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "impit"
-version = "0.12.0"
+version = "0.13.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Malformed cookies are silently ignored like in JS version.