### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 to resolve security alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary
Bumps the transitive `quinn-proto` dependency 0.11.14 → 0.11.15 in `Cargo.lock`, resolving the high-severity Dependabot alert [GHSA-4w2j-m93h-cj5j](https://github.com/apify/impit/security/dependabot) — remote memory exhaustion from unbounded out-of-order QUIC stream reassembly. This is reachable in impit's usage since it makes HTTP/3 requests to arbitrary (possibly hostile) servers.

Lockfile-only, patch-level change. `quinn-proto` 0.11.15 has an identical dependency set to 0.11.14 (verified against the crates.io index), so only the `version` and `checksum` lines change; the resolved graph is unchanged. `cargo` will validate the lockfile in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)