### PR TITLE
feat(rust): support streaming request bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "bytes",
  "encoding",
  "futures-core",
+ "futures-util",
  "hickory-proto",
  "hickory-resolver",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,7 +1299,9 @@ dependencies = [
 name = "impit"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "encoding",
+ "futures-core",
  "hickory-proto",
  "hickory-resolver",
  "hyper",

--- a/impit-node/src/lib.rs
+++ b/impit-node/src/lib.rs
@@ -138,7 +138,7 @@ impl ImpitWrapper {
       .unwrap_or_default();
     let body = request_init
       .and_then(|init| init.body)
-      .map(|array| array.to_vec());
+      .map(|array| array.to_vec().into());
 
     let response = if matches!(method, HttpMethod::Get | HttpMethod::Head) && body.is_some() {
       Err(ImpitError::BindingPassthroughError(

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -423,14 +423,14 @@ impl AsyncClient {
 
         pyo3_async_runtimes::tokio::future_into_py::<_, ImpitPyResponse>(py, async move {
             let response = match method_str.to_lowercase().as_str() {
-                "get" => impit.get(url, Some(body), Some(options)).await,
-                "post" => impit.post(url, Some(body), Some(options)).await,
-                "patch" => impit.patch(url, Some(body), Some(options)).await,
-                "put" => impit.put(url, Some(body), Some(options)).await,
-                "options" => impit.options(url, Some(body), Some(options)).await,
-                "trace" => impit.trace(url, Some(body), Some(options)).await,
-                "head" => impit.head(url, Some(body), Some(options)).await,
-                "delete" => impit.delete(url, Some(body), Some(options)).await,
+                "get" => impit.get(url, Some(body.into()), Some(options)).await,
+                "post" => impit.post(url, Some(body.into()), Some(options)).await,
+                "patch" => impit.patch(url, Some(body.into()), Some(options)).await,
+                "put" => impit.put(url, Some(body.into()), Some(options)).await,
+                "options" => impit.options(url, Some(body.into()), Some(options)).await,
+                "trace" => impit.trace(url, Some(body.into()), Some(options)).await,
+                "head" => impit.head(url, Some(body.into()), Some(options)).await,
+                "delete" => impit.delete(url, Some(body.into()), Some(options)).await,
                 _ => Err(ImpitError::InvalidMethod(method_str.to_string())),
             };
 

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -417,14 +417,14 @@ impl Client {
         py.detach(|| {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let response = match method.to_lowercase().as_str() {
-                    "get" => self.impit.get(url, Some(body), Some(options)).await,
-                    "post" => self.impit.post(url, Some(body), Some(options)).await,
-                    "patch" => self.impit.patch(url, Some(body), Some(options)).await,
-                    "put" => self.impit.put(url, Some(body), Some(options)).await,
-                    "options" => self.impit.options(url, Some(body), Some(options)).await,
-                    "trace" => self.impit.trace(url, Some(body), Some(options)).await,
-                    "head" => self.impit.head(url, Some(body), Some(options)).await,
-                    "delete" => self.impit.delete(url, Some(body), Some(options)).await,
+                    "get" => self.impit.get(url, Some(body.into()), Some(options)).await,
+                    "post" => self.impit.post(url, Some(body.into()), Some(options)).await,
+                    "patch" => self.impit.patch(url, Some(body.into()), Some(options)).await,
+                    "put" => self.impit.put(url, Some(body.into()), Some(options)).await,
+                    "options" => self.impit.options(url, Some(body.into()), Some(options)).await,
+                    "trace" => self.impit.trace(url, Some(body.into()), Some(options)).await,
+                    "head" => self.impit.head(url, Some(body.into()), Some(options)).await,
+                    "delete" => self.impit.delete(url, Some(body.into()), Some(options)).await,
                     _ => Err(ImpitError::InvalidMethod(method.to_string())),
                 };
 

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -419,12 +419,28 @@ impl Client {
                 let response = match method.to_lowercase().as_str() {
                     "get" => self.impit.get(url, Some(body.into()), Some(options)).await,
                     "post" => self.impit.post(url, Some(body.into()), Some(options)).await,
-                    "patch" => self.impit.patch(url, Some(body.into()), Some(options)).await,
+                    "patch" => {
+                        self.impit
+                            .patch(url, Some(body.into()), Some(options))
+                            .await
+                    }
                     "put" => self.impit.put(url, Some(body.into()), Some(options)).await,
-                    "options" => self.impit.options(url, Some(body.into()), Some(options)).await,
-                    "trace" => self.impit.trace(url, Some(body.into()), Some(options)).await,
+                    "options" => {
+                        self.impit
+                            .options(url, Some(body.into()), Some(options))
+                            .await
+                    }
+                    "trace" => {
+                        self.impit
+                            .trace(url, Some(body.into()), Some(options))
+                            .await
+                    }
                     "head" => self.impit.head(url, Some(body.into()), Some(options)).await,
-                    "delete" => self.impit.delete(url, Some(body.into()), Some(options)).await,
+                    "delete" => {
+                        self.impit
+                            .delete(url, Some(body.into()), Some(options))
+                            .await
+                    }
                     _ => Err(ImpitError::InvalidMethod(method.to_string())),
                 };
 

--- a/impit/Cargo.toml
+++ b/impit/Cargo.toml
@@ -25,3 +25,6 @@ hyper-util = "0.1.18"
 hyper = "1.7.0"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+futures-util = "0.3"

--- a/impit/Cargo.toml
+++ b/impit/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = "1"
 encoding = "0.2.33"
+futures-core = "0.3"
 hickory-proto = "0.26.1"
 hickory-resolver = "0.26.1"
 log = "0.4.22"

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -493,7 +493,9 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             body: request.body,
         };
 
-        let primary_result = self.execute_request(client, &mut prepared, timeout, h3).await;
+        let primary_result = self
+            .execute_request(client, &mut prepared, timeout, h3)
+            .await;
 
         let response = match primary_result {
             Ok(resp) => resp,

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -514,7 +514,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
                 let fallback_client = self
                     .vanilla_client
                     .as_ref()
-                    .filter(|_| primary_error.is_connect_error() && prepared.body.is_replayable());
+                    .filter(|_| primary_error.is_connect_error() && prepared.body.is_sendable());
                 let Some(vanilla_client) = fallback_client else {
                     return Err(primary_error);
                 };

--- a/impit/src/impit.rs
+++ b/impit/src/impit.rs
@@ -10,7 +10,7 @@ use crate::{
     fingerprint::BrowserFingerprint,
     http3::H3Engine,
     http_headers::HttpHeaders,
-    request::{ImpitRequest, RequestOptions},
+    request::{ImpitBody, ImpitRequest, RequestOptions},
     tls,
 };
 
@@ -31,7 +31,7 @@ struct PreparedRequest {
     method: Method,
     url: Url,
     headers: HeaderMap,
-    body: Option<Vec<u8>>,
+    body: ImpitBody,
 }
 
 impl<CookieStoreImpl: CookieStore + 'static> Default for Impit<CookieStoreImpl> {
@@ -401,7 +401,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
         &self,
         method: Method,
         url: Url,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         headers: Vec<(String, String)>,
     ) -> ImpitRequest {
         let host = url.host_str().unwrap_or_default().to_string();
@@ -416,7 +416,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
 
         ImpitRequest {
             url,
-            body,
+            body: body.unwrap_or_default(),
             headers: headers.iter().collect(),
             method: method.to_string(),
         }
@@ -425,7 +425,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     async fn execute_request(
         &self,
         client: &reqwest::Client,
-        prepared: &PreparedRequest,
+        prepared: &mut PreparedRequest,
         timeout: Option<Duration>,
         h3: bool,
     ) -> Result<Response, reqwest::Error> {
@@ -441,8 +441,8 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             req = req.timeout(t);
         }
 
-        if let Some(b) = prepared.body.clone() {
-            req = req.body(b);
+        if let Some(body) = prepared.body.take() {
+            req = req.body(body);
         }
 
         req.send().await
@@ -486,14 +486,14 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
             RedirectBehavior::ManualRedirect => 0,
         };
 
-        let prepared = PreparedRequest {
+        let mut prepared = PreparedRequest {
             method: method.clone(),
             url: request.url.clone(),
             headers: header_map,
             body: request.body,
         };
 
-        let primary_result = self.execute_request(client, &prepared, timeout, h3).await;
+        let primary_result = self.execute_request(client, &mut prepared, timeout, h3).await;
 
         let response = match primary_result {
             Ok(resp) => resp,
@@ -512,7 +512,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
                 let fallback_client = self
                     .vanilla_client
                     .as_ref()
-                    .filter(|_| primary_error.is_connect_error());
+                    .filter(|_| primary_error.is_connect_error() && prepared.body.is_replayable());
                 let Some(vanilla_client) = fallback_client else {
                     return Err(primary_error);
                 };
@@ -521,7 +521,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
                     "Primary request to {url} failed with {primary_error}, retrying with vanilla client"
                 );
                 match self
-                    .execute_request(vanilla_client, &prepared, timeout, false)
+                    .execute_request(vanilla_client, &mut prepared, timeout, false)
                     .await
                 {
                     Ok(resp) => resp,
@@ -555,7 +555,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
         &self,
         method: Method,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         let url = self.parse_url(url)?;
@@ -585,7 +585,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn get(
         &self,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         self.make_request(Method::GET, url, body, options).await
@@ -600,7 +600,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn head(
         &self,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         self.make_request(Method::HEAD, url, body, options).await
@@ -615,7 +615,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn options(
         &self,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         self.make_request(Method::OPTIONS, url, body, options).await
@@ -630,7 +630,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn trace(
         &self,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         self.make_request(Method::TRACE, url, body, options).await
@@ -645,7 +645,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn delete(
         &self,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         self.make_request(Method::DELETE, url, body, options).await
@@ -660,7 +660,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn post(
         &self,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         self.make_request(Method::POST, url, body, options).await
@@ -675,7 +675,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn put(
         &self,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         self.make_request(Method::PUT, url, body, options).await
@@ -690,7 +690,7 @@ impl<CookieStoreImpl: CookieStore + 'static> Impit<CookieStoreImpl> {
     pub async fn patch(
         &self,
         url: String,
-        body: Option<Vec<u8>>,
+        body: Option<ImpitBody>,
         options: Option<RequestOptions>,
     ) -> Result<Response, ImpitError> {
         self.make_request(Method::PATCH, url, body, options).await

--- a/impit/src/request.rs
+++ b/impit/src/request.rs
@@ -46,8 +46,11 @@ impl ImpitBody {
     /// Creates a streaming body from a stream of byte chunks.
     ///
     /// Unlike [`ImpitBody::Bytes`], the chunks are sent as they are produced, so the whole body
-    /// never has to be held in memory. The request uses `Transfer-Encoding: chunked` unless a
-    /// `Content-Length` header is set explicitly.
+    /// never has to be held in memory. On HTTP/1.1, the request uses `Transfer-Encoding: chunked`
+    /// unless a `Content-Length` header is set explicitly.
+    ///
+    /// As streamed bodies can't be replayed, `307` and `308` redirects aren't followed for such
+    /// requests - the redirect response is returned to the caller instead.
     pub fn from_stream<S>(stream: S) -> Self
     where
         S: TryStream + Send + 'static,

--- a/impit/src/request.rs
+++ b/impit/src/request.rs
@@ -93,3 +93,36 @@ pub struct ImpitRequest {
     pub headers: Vec<(String, String)>,
     pub method: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffered_bodies_can_be_sent_repeatedly() {
+        let mut body = ImpitBody::from("hello");
+
+        for _ in 0..2 {
+            assert!(body.is_sendable());
+            assert!(body.take().is_some());
+        }
+    }
+
+    #[test]
+    fn streamed_bodies_can_only_be_sent_once() {
+        let mut body =
+            ImpitBody::from_stream(futures_util::stream::empty::<Result<Bytes, std::io::Error>>());
+
+        assert!(body.take().is_some());
+        assert!(!body.is_sendable());
+        assert!(body.take().is_none());
+    }
+
+    #[test]
+    fn empty_bodies_yield_no_body() {
+        let mut body = ImpitBody::Empty;
+
+        assert!(body.take().is_none());
+        assert!(body.is_sendable());
+    }
+}

--- a/impit/src/request.rs
+++ b/impit/src/request.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use bytes::Bytes;
+use futures_core::TryStream;
 use url::Url;
 
 /// A struct that holds the request options.
@@ -24,9 +26,65 @@ pub struct RequestOptions {
     pub http3_prior_knowledge: bool,
 }
 
+/// The body of a request.
+#[derive(Default)]
+pub enum ImpitBody {
+    /// No request body.
+    #[default]
+    Empty,
+    /// A body that is fully buffered in memory before the request is sent.
+    Bytes(Vec<u8>),
+    /// A body that is streamed into the request as its chunks are produced.
+    ///
+    /// Note that streamed bodies can only be sent once, so requests using them are never retried.
+    Stream(reqwest::Body),
+    /// A streamed body that has already been sent and cannot be replayed.
+    Consumed,
+}
+
+impl ImpitBody {
+    /// Creates a streaming body from a stream of byte chunks.
+    ///
+    /// Unlike [`ImpitBody::Bytes`], the chunks are sent as they are produced, so the whole body
+    /// never has to be held in memory. The request uses `Transfer-Encoding: chunked` unless a
+    /// `Content-Length` header is set explicitly.
+    pub fn from_stream<S>(stream: S) -> Self
+    where
+        S: TryStream + Send + 'static,
+        S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        Bytes: From<S::Ok>,
+    {
+        Self::Stream(reqwest::Body::wrap_stream(stream))
+    }
+
+    pub(crate) fn take(&mut self) -> Option<reqwest::Body> {
+        match std::mem::replace(self, Self::Consumed) {
+            Self::Bytes(bytes) => {
+                *self = Self::Bytes(bytes.clone());
+                Some(bytes.into())
+            }
+            Self::Stream(body) => Some(body),
+            body => {
+                *self = body;
+                None
+            }
+        }
+    }
+
+    pub(crate) fn is_replayable(&self) -> bool {
+        !matches!(self, Self::Consumed)
+    }
+}
+
+impl From<Vec<u8>> for ImpitBody {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self::Bytes(bytes)
+    }
+}
+
 pub struct ImpitRequest {
     pub url: Url,
-    pub body: Option<Vec<u8>>,
+    pub body: ImpitBody,
     pub headers: Vec<(String, String)>,
     pub method: String,
 }

--- a/impit/src/request.rs
+++ b/impit/src/request.rs
@@ -33,7 +33,7 @@ pub enum ImpitBody {
     #[default]
     Empty,
     /// A body that is fully buffered in memory before the request is sent.
-    Bytes(Vec<u8>),
+    Bytes(Bytes),
     /// A body that is streamed into the request as its chunks are produced.
     ///
     /// Note that streamed bodies can only be sent once, so requests using them are never retried.
@@ -78,9 +78,9 @@ impl ImpitBody {
     }
 }
 
-impl From<Vec<u8>> for ImpitBody {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self::Bytes(bytes)
+impl<T: Into<Bytes>> From<T> for ImpitBody {
+    fn from(bytes: T) -> Self {
+        Self::Bytes(bytes.into())
     }
 }
 

--- a/impit/src/request.rs
+++ b/impit/src/request.rs
@@ -71,7 +71,9 @@ impl ImpitBody {
         }
     }
 
-    pub(crate) fn is_replayable(&self) -> bool {
+    /// Whether a body is still available to send - `false` only for a streamed body that has
+    /// already been consumed by a previous attempt.
+    pub(crate) fn is_sendable(&self) -> bool {
         !matches!(self, Self::Consumed)
     }
 }


### PR DESCRIPTION
Adds `ImpitBody`, letting the core crate stream request bodies into reqwest instead of always buffering them; bindings support comes in follow-ups.

Related: #513