### PR TITLE
feat(python): stream iterator request bodies

### DIFF
--- a/impit-python/python/impit/impit.pyi
+++ b/impit-python/python/impit/impit.pyi
@@ -518,7 +518,7 @@ class Client:
     def get(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -538,7 +538,7 @@ class Client:
     def post(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -559,7 +559,7 @@ class Client:
     def put(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -579,7 +579,7 @@ class Client:
     def patch(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -599,7 +599,7 @@ class Client:
     def delete(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -619,7 +619,7 @@ class Client:
     def head(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -639,7 +639,7 @@ class Client:
     def options(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -659,7 +659,7 @@ class Client:
     def trace(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -680,7 +680,7 @@ class Client:
         self,
         method: str,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -704,7 +704,7 @@ class Client:
         self,
         method: str,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -859,7 +859,7 @@ class AsyncClient:
     async def get(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -879,7 +879,7 @@ class AsyncClient:
     async def post(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -900,7 +900,7 @@ class AsyncClient:
     async def put(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -920,7 +920,7 @@ class AsyncClient:
     async def patch(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -940,7 +940,7 @@ class AsyncClient:
     async def delete(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -960,7 +960,7 @@ class AsyncClient:
     async def head(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -980,7 +980,7 @@ class AsyncClient:
     async def options(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1000,7 +1000,7 @@ class AsyncClient:
     async def trace(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1021,7 +1021,7 @@ class AsyncClient:
         self,
         method: str,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1045,7 +1045,7 @@ class AsyncClient:
         self,
         method: str,
         url: str,
-        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
+        content: bytes | bytearray | str | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1078,7 +1078,7 @@ class AsyncClient:
 def stream(
     method: str,
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1111,7 +1111,7 @@ def stream(
 
 def get(
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1144,7 +1144,7 @@ def get(
 
 def post(
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1177,7 +1177,7 @@ def post(
 
 def put(
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1210,7 +1210,7 @@ def put(
 
 def patch(
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1243,7 +1243,7 @@ def patch(
 
 def delete(
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1276,7 +1276,7 @@ def delete(
 
 def head(
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1309,7 +1309,7 @@ def head(
 
 def options(
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1339,7 +1339,7 @@ def options(
 
 def trace(
     url: str,
-    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
+    content: bytes | bytearray | str | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,

--- a/impit-python/python/impit/impit.pyi
+++ b/impit-python/python/impit/impit.pyi
@@ -6,7 +6,7 @@ from .headers import Headers
 from . import Browser
 
 from typing import Any
-from collections.abc import Iterator, AsyncIterator
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 
 
@@ -518,7 +518,7 @@ class Client:
     def get(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -538,7 +538,7 @@ class Client:
     def post(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -559,7 +559,7 @@ class Client:
     def put(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -579,7 +579,7 @@ class Client:
     def patch(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -599,7 +599,7 @@ class Client:
     def delete(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -619,7 +619,7 @@ class Client:
     def head(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -639,7 +639,7 @@ class Client:
     def options(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -659,7 +659,7 @@ class Client:
     def trace(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -680,7 +680,7 @@ class Client:
         self,
         method: str,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -704,7 +704,7 @@ class Client:
         self,
         method: str,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -859,7 +859,7 @@ class AsyncClient:
     async def get(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -879,7 +879,7 @@ class AsyncClient:
     async def post(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -900,7 +900,7 @@ class AsyncClient:
     async def put(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -920,7 +920,7 @@ class AsyncClient:
     async def patch(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -940,7 +940,7 @@ class AsyncClient:
     async def delete(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -960,7 +960,7 @@ class AsyncClient:
     async def head(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -980,7 +980,7 @@ class AsyncClient:
     async def options(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1000,7 +1000,7 @@ class AsyncClient:
     async def trace(
         self,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1021,7 +1021,7 @@ class AsyncClient:
         self,
         method: str,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1045,7 +1045,7 @@ class AsyncClient:
         self,
         method: str,
         url: str,
-        content: bytes | bytearray | list[int] | None = None,
+        content: bytes | bytearray | list[int] | Iterable[bytes] | AsyncIterable[bytes] | None = None,
         data: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1078,7 +1078,7 @@ class AsyncClient:
 def stream(
     method: str,
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1111,7 +1111,7 @@ def stream(
 
 def get(
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1144,7 +1144,7 @@ def get(
 
 def post(
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1177,7 +1177,7 @@ def post(
 
 def put(
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1210,7 +1210,7 @@ def put(
 
 def patch(
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1243,7 +1243,7 @@ def patch(
 
 def delete(
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1276,7 +1276,7 @@ def delete(
 
 def head(
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1309,7 +1309,7 @@ def head(
 
 def options(
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,
@@ -1339,7 +1339,7 @@ def options(
 
 def trace(
     url: str,
-    content: bytes | bytearray | list[int] | None = None,
+    content: bytes | bytearray | list[int] | Iterable[bytes] | None = None,
     data: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
     timeout: float | str | None = USE_CLIENT_DEFAULT,

--- a/impit-python/src/async_client.rs
+++ b/impit-python/src/async_client.rs
@@ -6,12 +6,12 @@ use impit::{
     impit::{Impit, ImpitBuilder},
     request::RequestOptions,
 };
-use pyo3::{exceptions::PyTypeError, ffi::c_str, prelude::*};
+use pyo3::{ffi::c_str, prelude::*};
 
 use crate::{
     cookies::PythonCookieJar,
     errors::ImpitPyError,
-    request::{form_to_bytes, parse_timeout, RequestBody, USE_CLIENT_DEFAULT_SENTINEL},
+    request::{parse_timeout, to_body, RequestBody, USE_CLIENT_DEFAULT_SENTINEL},
     response::ImpitPyResponse,
 };
 
@@ -135,7 +135,7 @@ impl AsyncClient {
         &self,
         py: Python<'python>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -159,7 +159,7 @@ impl AsyncClient {
         &self,
         py: Python<'python>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -183,7 +183,7 @@ impl AsyncClient {
         &self,
         py: Python<'python>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -207,7 +207,7 @@ impl AsyncClient {
         &self,
         py: Python<'python>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -231,7 +231,7 @@ impl AsyncClient {
         &self,
         py: Python<'python>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -255,7 +255,7 @@ impl AsyncClient {
         &self,
         py: Python<'python>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -279,7 +279,7 @@ impl AsyncClient {
         &self,
         py: Python<'python>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -303,7 +303,7 @@ impl AsyncClient {
         &self,
         py: Python<'python>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -328,7 +328,7 @@ impl AsyncClient {
         py: Python<'python>,
         method: &str,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -374,7 +374,7 @@ impl AsyncClient {
         py: Python<'python>,
         method: &str,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         mut data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -384,25 +384,10 @@ impl AsyncClient {
         let mut headers = headers.clone();
 
         if let Some(content) = content {
-            data = Some(RequestBody::Bytes(content));
+            data = Some(content);
         }
 
-        let body: Vec<u8> = match data {
-            Some(data) => match data {
-                RequestBody::Bytes(bytes) => Ok(bytes),
-                RequestBody::Form(form) => {
-                    headers.get_or_insert_with(HashMap::new).insert(
-                        "Content-Type".to_string(),
-                        "application/x-www-form-urlencoded".to_string(),
-                    );
-                    Ok(form_to_bytes(form))
-                }
-                RequestBody::CatchAll(e) => Err(PyErr::new::<PyTypeError, _>(format!(
-                    "Unsupported data type in request body: {e:#?}"
-                ))),
-            },
-            None => Ok(Vec::new()),
-        }?;
+        let body = to_body(data, &mut headers)?;
 
         let timeout = parse_timeout(timeout)?;
 
@@ -423,14 +408,14 @@ impl AsyncClient {
 
         pyo3_async_runtimes::tokio::future_into_py::<_, ImpitPyResponse>(py, async move {
             let response = match method_str.to_lowercase().as_str() {
-                "get" => impit.get(url, Some(body.into()), Some(options)).await,
-                "post" => impit.post(url, Some(body.into()), Some(options)).await,
-                "patch" => impit.patch(url, Some(body.into()), Some(options)).await,
-                "put" => impit.put(url, Some(body.into()), Some(options)).await,
-                "options" => impit.options(url, Some(body.into()), Some(options)).await,
-                "trace" => impit.trace(url, Some(body.into()), Some(options)).await,
-                "head" => impit.head(url, Some(body.into()), Some(options)).await,
-                "delete" => impit.delete(url, Some(body.into()), Some(options)).await,
+                "get" => impit.get(url, Some(body), Some(options)).await,
+                "post" => impit.post(url, Some(body), Some(options)).await,
+                "patch" => impit.patch(url, Some(body), Some(options)).await,
+                "put" => impit.put(url, Some(body), Some(options)).await,
+                "options" => impit.options(url, Some(body), Some(options)).await,
+                "trace" => impit.trace(url, Some(body), Some(options)).await,
+                "head" => impit.head(url, Some(body), Some(options)).await,
+                "delete" => impit.delete(url, Some(body), Some(options)).await,
                 _ => Err(ImpitError::InvalidMethod(method_str.to_string())),
             };
 

--- a/impit-python/src/client.rs
+++ b/impit-python/src/client.rs
@@ -11,7 +11,7 @@ use pyo3::{ffi::c_str, prelude::*};
 use crate::{
     cookies::PythonCookieJar,
     errors::ImpitPyError,
-    request::{form_to_bytes, parse_timeout, RequestBody, USE_CLIENT_DEFAULT_SENTINEL},
+    request::{parse_timeout, to_body, RequestBody, USE_CLIENT_DEFAULT_SENTINEL},
     response::{self, ImpitPyResponse},
 };
 
@@ -132,7 +132,7 @@ impl Client {
         &self,
         py: Python<'_>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -156,7 +156,7 @@ impl Client {
         &self,
         py: Python<'_>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -180,7 +180,7 @@ impl Client {
         &self,
         py: Python<'_>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -204,7 +204,7 @@ impl Client {
         &self,
         py: Python<'_>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -228,7 +228,7 @@ impl Client {
         &self,
         py: Python<'_>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -252,7 +252,7 @@ impl Client {
         &self,
         py: Python<'_>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -276,7 +276,7 @@ impl Client {
         &self,
         py: Python<'_>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -300,7 +300,7 @@ impl Client {
         &self,
         py: Python<'_>,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -325,7 +325,7 @@ impl Client {
         py: Python<'python>,
         method: &str,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -371,7 +371,7 @@ impl Client {
         py: Python<'_>,
         method: &str,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         mut data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,
@@ -381,25 +381,11 @@ impl Client {
         let mut headers = headers.clone();
 
         if let Some(content) = content {
-            data = Some(RequestBody::Bytes(content));
+            data = Some(content);
         }
 
-        let body: Vec<u8> = match data {
-            Some(data) => match data {
-                RequestBody::Bytes(bytes) => Ok(bytes),
-                RequestBody::Form(form) => {
-                    headers.get_or_insert_with(HashMap::new).insert(
-                        "Content-Type".to_string(),
-                        "application/x-www-form-urlencoded".to_string(),
-                    );
-                    Ok(form_to_bytes(form))
-                }
-                RequestBody::CatchAll(e) => Err(ImpitPyError(ImpitError::BindingPassthroughError(
-                    format!("Unsupported data type: {e:?}").to_string(),
-                ))),
-            },
-            None => Ok(Vec::new()),
-        }?;
+        let body = to_body(data, &mut headers)
+            .map_err(|e| ImpitPyError(ImpitError::BindingPassthroughError(e.to_string())))?;
 
         let timeout = parse_timeout(timeout)
             .map_err(|e| ImpitPyError(ImpitError::BindingPassthroughError(e.to_string())))?;
@@ -417,30 +403,14 @@ impl Client {
         py.detach(|| {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let response = match method.to_lowercase().as_str() {
-                    "get" => self.impit.get(url, Some(body.into()), Some(options)).await,
-                    "post" => self.impit.post(url, Some(body.into()), Some(options)).await,
-                    "patch" => {
-                        self.impit
-                            .patch(url, Some(body.into()), Some(options))
-                            .await
-                    }
-                    "put" => self.impit.put(url, Some(body.into()), Some(options)).await,
-                    "options" => {
-                        self.impit
-                            .options(url, Some(body.into()), Some(options))
-                            .await
-                    }
-                    "trace" => {
-                        self.impit
-                            .trace(url, Some(body.into()), Some(options))
-                            .await
-                    }
-                    "head" => self.impit.head(url, Some(body.into()), Some(options)).await,
-                    "delete" => {
-                        self.impit
-                            .delete(url, Some(body.into()), Some(options))
-                            .await
-                    }
+                    "get" => self.impit.get(url, Some(body), Some(options)).await,
+                    "post" => self.impit.post(url, Some(body), Some(options)).await,
+                    "patch" => self.impit.patch(url, Some(body), Some(options)).await,
+                    "put" => self.impit.put(url, Some(body), Some(options)).await,
+                    "options" => self.impit.options(url, Some(body), Some(options)).await,
+                    "trace" => self.impit.trace(url, Some(body), Some(options)).await,
+                    "head" => self.impit.head(url, Some(body), Some(options)).await,
+                    "delete" => self.impit.delete(url, Some(body), Some(options)).await,
                     _ => Err(ImpitError::InvalidMethod(method.to_string())),
                 };
 

--- a/impit-python/src/lib.rs
+++ b/impit-python/src/lib.rs
@@ -93,7 +93,7 @@ fn impit(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
             fn $name(
                 _py: Python,
                 url: String,
-                content: Option<Vec<u8>>,
+                content: Option<RequestBody>,
                 data: Option<RequestBody>,
                 headers: Option<HashMap<String, String>>,
                 timeout: Option<Either<f64, &str>>,
@@ -122,7 +122,7 @@ fn impit(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
         _py: Python<'python>,
         method: &str,
         url: String,
-        content: Option<Vec<u8>>,
+        content: Option<RequestBody>,
         data: Option<RequestBody>,
         headers: Option<HashMap<String, String>>,
         timeout: Option<Either<f64, &str>>,

--- a/impit-python/src/request.rs
+++ b/impit-python/src/request.rs
@@ -49,6 +49,8 @@ pub(crate) enum RequestBody {
     Bytes(Vec<u8>),
     #[pyo3(transparent, annotation = "dict[str, str]")]
     Form(HashMap<String, String>),
+    #[pyo3(transparent, annotation = "str")]
+    Text(String),
     #[pyo3(transparent, annotation = "Iterable[bytes] | AsyncIterable[bytes]")]
     Iterator(PyIterator),
     #[pyo3(transparent)]
@@ -141,6 +143,7 @@ pub(crate) fn to_body(
             );
             form_to_bytes(form).into()
         }
+        Some(RequestBody::Text(text)) => text.into_bytes().into(),
         Some(RequestBody::Iterator(iterator)) => ImpitBody::from_stream(to_stream(iterator)),
         Some(RequestBody::CatchAll(object)) => {
             return Err(Python::attach(|py| {

--- a/impit-python/src/request.rs
+++ b/impit-python/src/request.rs
@@ -6,7 +6,7 @@ use futures::{stream, Stream};
 use impit::request::ImpitBody;
 use pyo3::{
     exceptions::{PyStopAsyncIteration, PyStopIteration, PyTypeError},
-    types::PyAnyMethods,
+    types::{PyAnyMethods, PyMapping},
     Borrowed, Bound, Py, PyAny, PyErr, PyResult, PyTypeInfo, Python,
 };
 use pyo3_async_runtimes::TaskLocals;
@@ -65,6 +65,10 @@ impl<'py> FromPyObject<'_, 'py> for PyIterator {
     type Error = PyErr;
 
     fn extract(object: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        if object.is_instance_of::<PyMapping>() {
+            return Err(PyTypeError::new_err("not an iterator over byte chunks"));
+        }
+
         match object.call_method0("__aiter__") {
             Ok(iterator) => Ok(Self::Async(
                 iterator.unbind(),

--- a/impit-python/src/request.rs
+++ b/impit-python/src/request.rs
@@ -1,7 +1,15 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, io, time::Duration};
 
+use bytes::Bytes;
 use either::{Either, Left, Right};
-use pyo3::{Bound, PyAny};
+use futures::{stream, Stream};
+use impit::request::ImpitBody;
+use pyo3::{
+    exceptions::{PyStopAsyncIteration, PyStopIteration, PyTypeError},
+    types::PyAnyMethods,
+    Borrowed, Bound, Py, PyAny, PyErr, PyResult, PyTypeInfo, Python,
+};
+use pyo3_async_runtimes::TaskLocals;
 
 /// The sentinel string used as the Python default value for per-request `timeout` parameters.
 ///
@@ -36,13 +44,109 @@ pub(crate) fn parse_timeout(
 use pyo3::FromPyObject;
 
 #[derive(FromPyObject)]
-pub(crate) enum RequestBody<'py> {
+pub(crate) enum RequestBody {
     #[pyo3(transparent, annotation = "bytes")]
     Bytes(Vec<u8>),
     #[pyo3(transparent, annotation = "dict[str, str]")]
     Form(HashMap<String, String>),
+    #[pyo3(transparent, annotation = "Iterable[bytes] | AsyncIterable[bytes]")]
+    Iterator(PyIterator),
     #[pyo3(transparent)]
-    CatchAll(Bound<'py, PyAny>), // This extraction never fails
+    CatchAll(Py<PyAny>), // This extraction never fails
+}
+
+/// A Python iterator over the chunks of a request body.
+pub(crate) enum PyIterator {
+    Sync(Py<PyAny>),
+    Async(Py<PyAny>, TaskLocals),
+}
+
+impl<'py> FromPyObject<'_, 'py> for PyIterator {
+    type Error = PyErr;
+
+    fn extract(object: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        match object.call_method0("__aiter__") {
+            Ok(iterator) => Ok(Self::Async(
+                iterator.unbind(),
+                TaskLocals::with_running_loop(object.py())?.copy_context(object.py())?,
+            )),
+            Err(_) => Ok(Self::Sync(object.try_iter()?.into_any().unbind())),
+        }
+    }
+}
+
+fn to_chunk<Stop: PyTypeInfo>(next: PyResult<Py<PyAny>>) -> Option<io::Result<Bytes>> {
+    Python::attach(|py| match next {
+        Ok(chunk) => Some(
+            chunk
+                .extract::<Vec<u8>>(py)
+                .map(Bytes::from)
+                .map_err(io::Error::other),
+        ),
+        Err(err) if err.is_instance_of::<Stop>(py) => None,
+        Err(err) => Some(Err(io::Error::other(err))),
+    })
+}
+
+fn to_stream(iterator: PyIterator) -> impl Stream<Item = io::Result<Bytes>> {
+    stream::unfold(iterator, |iterator| async move {
+        let chunk = match &iterator {
+            PyIterator::Sync(iterator) => {
+                let iterator = Python::attach(|py| iterator.clone_ref(py));
+                tokio::task::spawn_blocking(move || {
+                    to_chunk::<PyStopIteration>(Python::attach(|py| {
+                        iterator
+                            .bind(py)
+                            .call_method0("__next__")
+                            .map(Bound::unbind)
+                    }))
+                })
+                .await
+                .unwrap_or_else(|err| Some(Err(io::Error::other(err))))
+            }
+            PyIterator::Async(iterator, locals) => {
+                let next = Python::attach(|py| {
+                    pyo3_async_runtimes::into_future_with_locals(
+                        locals,
+                        iterator.bind(py).call_method0("__anext__")?,
+                    )
+                });
+                to_chunk::<PyStopAsyncIteration>(match next {
+                    Ok(next) => next.await,
+                    Err(err) => Err(err),
+                })
+            }
+        };
+
+        Some((chunk?, iterator))
+    })
+}
+
+/// Converts the Python request body into an [`ImpitBody`], streaming it if it is an iterator.
+pub(crate) fn to_body(
+    data: Option<RequestBody>,
+    headers: &mut Option<HashMap<String, String>>,
+) -> PyResult<ImpitBody> {
+    Ok(match data {
+        None => ImpitBody::Empty,
+        Some(RequestBody::Bytes(bytes)) => bytes.into(),
+        Some(RequestBody::Form(form)) => {
+            headers.get_or_insert_default().insert(
+                "Content-Type".to_string(),
+                "application/x-www-form-urlencoded".to_string(),
+            );
+            form_to_bytes(form).into()
+        }
+        Some(RequestBody::Iterator(iterator)) => ImpitBody::from_stream(to_stream(iterator)),
+        Some(RequestBody::CatchAll(object)) => {
+            return Err(Python::attach(|py| {
+                PyErr::new::<PyTypeError, _>(format!(
+                    "Unsupported data type in request body: {}",
+                    object.bind(py).get_type()
+                ))
+            }))
+        }
+    })
 }
 
 pub fn form_to_bytes(data: HashMap<String, String>) -> Vec<u8> {

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import socket
 import threading
+from collections.abc import AsyncIterator
 from http.cookiejar import Cookie, CookieJar
 from typing import Literal
 
@@ -72,6 +73,25 @@ def header_encoding_server(port_holder: list[int]) -> None:
         ]
     )
     conn.send(response)
+    conn.close()
+    server.close()
+
+
+def echoing_server(port_holder: list[int]) -> None:
+    """Echo the raw request (request line, headers and body) back in the response body."""
+    server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    server.bind(('::', 0))
+    port_holder[0] = server.getsockname()[1]
+    server.listen(1)
+
+    conn, _ = server.accept()
+    conn.settimeout(5)
+    request = b''
+    while not request.endswith(b'0\r\n\r\n'):
+        request += conn.recv(1024)
+    conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
     conn.close()
     server.close()
 
@@ -525,6 +545,24 @@ class TestRequestBody:
         )
         assert response.status_code == 200
         assert json.loads(response.text)['data'] == '{"Impit-Test":"foořžš"}'
+
+    @pytest.mark.asyncio
+    async def test_passing_async_iterator_body(self, browser: Browser) -> None:
+        port_holder = [0]
+        thread = threading.Thread(target=echoing_server, args=(port_holder,))
+        thread.start()
+        await asyncio.sleep(0.1)
+
+        async def chunks() -> AsyncIterator[bytes]:
+            yield b'{"Impit-Test":'
+            yield b'"foo"}'
+
+        impit = AsyncClient(browser=browser)
+
+        response = await impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=5)
+        assert 'transfer-encoding: chunked' in response.text.lower()
+        assert response.text.endswith('E\r\n{"Impit-Test":\r\n6\r\n"foo"}\r\n0\r\n\r\n')
+        thread.join()
 
     @pytest.mark.asyncio
     async def test_passing_string_body_in_data(self, browser: Browser) -> None:

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -3,7 +3,7 @@ import contextlib
 import json
 import socket
 import threading
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from http.cookiejar import Cookie, CookieJar
 from typing import Literal
 
@@ -78,8 +78,9 @@ def header_encoding_server(port_holder: list[int]) -> None:
     server.close()
 
 
-def echoing_server(port_holder: list[int], body_started: threading.Event | None = None) -> None:
-    """Echo the raw request (request line, headers and body) back in the response body.
+@contextlib.contextmanager
+def echoing_server(body_started: threading.Event | None = None) -> Iterator[int]:
+    """Serve a single request, echoing it back in the response body, and yield the port to call.
 
     `body_started` is set as soon as the first body byte arrives, before the request is complete.
     """
@@ -87,20 +88,27 @@ def echoing_server(port_holder: list[int], body_started: threading.Event | None 
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
     server.bind(('::', 0))
-    port_holder[0] = server.getsockname()[1]
     server.listen(1)
 
-    conn, _ = server.accept()
-    conn.settimeout(5)
-    request = b''
-    with contextlib.suppress(TimeoutError):
-        while not request.endswith(b'0\r\n\r\n'):
-            request += conn.recv(1024)
-            if body_started is not None and request.partition(b'\r\n\r\n')[2]:
-                body_started.set()
-    conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
-    conn.close()
-    server.close()
+    def echo() -> None:
+        conn, _ = server.accept()
+        conn.settimeout(5)
+        request = b''
+        with contextlib.suppress(TimeoutError):
+            while not request.endswith(b'0\r\n\r\n'):
+                request += conn.recv(1024)
+                if body_started is not None and request.partition(b'\r\n\r\n')[2]:
+                    body_started.set()
+        conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
+        conn.close()
+
+    thread = threading.Thread(target=echo, daemon=True)
+    thread.start()
+    try:
+        yield server.getsockname()[1]
+    finally:
+        thread.join(5)
+        server.close()
 
 
 @pytest.mark.asyncio
@@ -555,30 +563,21 @@ class TestRequestBody:
 
     @pytest.mark.asyncio
     async def test_passing_async_iterator_body(self, browser: Browser) -> None:
-        port_holder = [0]
-        thread = threading.Thread(target=echoing_server, args=(port_holder,))
-        thread.start()
-        await asyncio.sleep(0.1)
-
         async def chunks() -> AsyncIterator[bytes]:
             yield b'{"Impit-Test":'
             yield b'"foo"}'
 
         impit = AsyncClient(browser=browser)
 
-        response = await impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=5)
+        with echoing_server() as port:
+            response = await impit.post(f'http://localhost:{port}/', content=chunks(), timeout=5)
+
         assert 'transfer-encoding: chunked' in response.text.lower()
         assert response.text.endswith('E\r\n{"Impit-Test":\r\n6\r\n"foo"}\r\n0\r\n\r\n')
-        thread.join()
 
     @pytest.mark.asyncio
     async def test_async_iterator_body_is_not_buffered(self, browser: Browser) -> None:
-        port_holder = [0]
         body_started = threading.Event()
-        thread = threading.Thread(target=echoing_server, args=(port_holder, body_started))
-        thread.start()
-        await asyncio.sleep(0.1)
-
         sent_before_next_chunk = []
 
         async def chunks() -> AsyncIterator[bytes]:
@@ -588,10 +587,11 @@ class TestRequestBody:
 
         impit = AsyncClient(browser=browser)
 
-        response = await impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=10)
+        with echoing_server(body_started) as port:
+            response = await impit.post(f'http://localhost:{port}/', content=chunks(), timeout=10)
+
         assert sent_before_next_chunk == [True], 'the whole body was read before the request was sent'
         assert response.text.endswith('5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n')
-        thread.join()
 
     @pytest.mark.asyncio
     async def test_passing_string_body_in_data(self, browser: Browser) -> None:

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -9,7 +9,16 @@ from typing import Literal
 
 import pytest
 
-from impit import AsyncClient, Browser, Cookies, RemoteProtocolError, StreamClosed, StreamConsumed, TooManyRedirects
+from impit import (
+    AsyncClient,
+    Browser,
+    Cookies,
+    HTTPError,
+    RemoteProtocolError,
+    StreamClosed,
+    StreamConsumed,
+    TooManyRedirects,
+)
 
 from .httpbin import get_httpbin_url
 from .setup_proxy import start_proxy_server
@@ -592,6 +601,14 @@ class TestRequestBody:
 
         assert sent_before_next_chunk == [True], 'the whole body was read before the request was sent'
         assert response.text.endswith('5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n')
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('body', [{'Impit-Test': 1}, 42])
+    async def test_unsupported_body_type(self, browser: Browser, body: object) -> None:
+        impit = AsyncClient(browser=browser)
+
+        with pytest.raises((TypeError, HTTPError), match='Unsupported data type'):
+            await impit.post('http://localhost:1/', content=body, timeout=5)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_passing_string_body_in_data(self, browser: Browser) -> None:

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -570,6 +570,16 @@ class TestRequestBody:
         assert response.text.endswith('5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n')
 
     @pytest.mark.asyncio
+    async def test_passing_str_body(self, browser: Browser) -> None:
+        impit = AsyncClient(browser=browser)
+
+        with echoing_server() as port:
+            response = await impit.post(f'http://localhost:{port}/', content='Impit-Test: foořžš', timeout=5)
+
+        assert 'content-length: 21' in response.text.lower()
+        assert response.text.endswith('Impit-Test: foořžš')
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('body', [{'Impit-Test': 1}, 42])
     async def test_unsupported_body_type(self, browser: Browser, body: object) -> None:
         impit = AsyncClient(browser=browser)

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -1,9 +1,8 @@
 import asyncio
-import contextlib
 import json
 import socket
 import threading
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
 from http.cookiejar import Cookie, CookieJar
 from typing import Literal
 
@@ -21,6 +20,7 @@ from impit import (
 )
 
 from .httpbin import get_httpbin_url
+from .servers import echoing_server
 from .setup_proxy import start_proxy_server
 
 
@@ -85,39 +85,6 @@ def header_encoding_server(port_holder: list[int]) -> None:
     conn.send(response)
     conn.close()
     server.close()
-
-
-@contextlib.contextmanager
-def echoing_server(body_started: threading.Event | None = None) -> Iterator[int]:
-    """Serve a single request, echoing it back in the response body, and yield the port to call.
-
-    `body_started` is set as soon as the first body byte arrives, before the request is complete.
-    """
-    server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-    server.bind(('::', 0))
-    server.listen(1)
-
-    def echo() -> None:
-        conn, _ = server.accept()
-        conn.settimeout(5)
-        request = b''
-        with contextlib.suppress(TimeoutError):
-            while not request.endswith(b'0\r\n\r\n'):
-                request += conn.recv(1024)
-                if body_started is not None and request.partition(b'\r\n\r\n')[2]:
-                    body_started.set()
-        conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
-        conn.close()
-
-    thread = threading.Thread(target=echo, daemon=True)
-    thread.start()
-    try:
-        yield server.getsockname()[1]
-    finally:
-        thread.join(5)
-        server.close()
 
 
 @pytest.mark.asyncio

--- a/impit-python/test/async_client_test.py
+++ b/impit-python/test/async_client_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 import socket
 import threading
@@ -77,8 +78,11 @@ def header_encoding_server(port_holder: list[int]) -> None:
     server.close()
 
 
-def echoing_server(port_holder: list[int]) -> None:
-    """Echo the raw request (request line, headers and body) back in the response body."""
+def echoing_server(port_holder: list[int], body_started: threading.Event | None = None) -> None:
+    """Echo the raw request (request line, headers and body) back in the response body.
+
+    `body_started` is set as soon as the first body byte arrives, before the request is complete.
+    """
     server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
@@ -89,8 +93,11 @@ def echoing_server(port_holder: list[int]) -> None:
     conn, _ = server.accept()
     conn.settimeout(5)
     request = b''
-    while not request.endswith(b'0\r\n\r\n'):
-        request += conn.recv(1024)
+    with contextlib.suppress(TimeoutError):
+        while not request.endswith(b'0\r\n\r\n'):
+            request += conn.recv(1024)
+            if body_started is not None and request.partition(b'\r\n\r\n')[2]:
+                body_started.set()
     conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
     conn.close()
     server.close()
@@ -562,6 +569,28 @@ class TestRequestBody:
         response = await impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=5)
         assert 'transfer-encoding: chunked' in response.text.lower()
         assert response.text.endswith('E\r\n{"Impit-Test":\r\n6\r\n"foo"}\r\n0\r\n\r\n')
+        thread.join()
+
+    @pytest.mark.asyncio
+    async def test_async_iterator_body_is_not_buffered(self, browser: Browser) -> None:
+        port_holder = [0]
+        body_started = threading.Event()
+        thread = threading.Thread(target=echoing_server, args=(port_holder, body_started))
+        thread.start()
+        await asyncio.sleep(0.1)
+
+        sent_before_next_chunk = []
+
+        async def chunks() -> AsyncIterator[bytes]:
+            yield b'first'
+            sent_before_next_chunk.append(await asyncio.to_thread(body_started.wait, 5))
+            yield b'second'
+
+        impit = AsyncClient(browser=browser)
+
+        response = await impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=10)
+        assert sent_before_next_chunk == [True], 'the whole body was read before the request was sent'
+        assert response.text.endswith('5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n')
         thread.join()
 
     @pytest.mark.asyncio

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -1,4 +1,3 @@
-import contextlib
 import json
 import socket
 import threading
@@ -25,6 +24,7 @@ from impit import (
 )
 
 from .httpbin import get_httpbin_url
+from .servers import echoing_server
 from .setup_proxy import start_proxy_server
 
 
@@ -59,39 +59,6 @@ def truncating_server(port_holder: list[int]) -> None:
     conn.send(b'HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n0123456789')
     conn.close()
     server.close()
-
-
-@contextlib.contextmanager
-def echoing_server(body_started: threading.Event | None = None) -> Iterator[int]:
-    """Serve a single request, echoing it back in the response body, and yield the port to call.
-
-    `body_started` is set as soon as the first body byte arrives, before the request is complete.
-    """
-    server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-    server.bind(('::', 0))
-    server.listen(1)
-
-    def echo() -> None:
-        conn, _ = server.accept()
-        conn.settimeout(5)
-        request = b''
-        with contextlib.suppress(TimeoutError):
-            while not request.endswith(b'0\r\n\r\n'):
-                request += conn.recv(1024)
-                if body_started is not None and request.partition(b'\r\n\r\n')[2]:
-                    body_started.set()
-        conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
-        conn.close()
-
-    thread = threading.Thread(target=echo, daemon=True)
-    thread.start()
-    try:
-        yield server.getsockname()[1]
-    finally:
-        thread.join(5)
-        server.close()
 
 
 @pytest.mark.parametrize(

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -2,6 +2,7 @@ import json
 import socket
 import threading
 import time
+from collections.abc import Iterator
 from http.cookiejar import Cookie, CookieJar
 from typing import Literal
 
@@ -54,6 +55,25 @@ def truncating_server(port_holder: list[int]) -> None:
     conn, _ = server.accept()
     conn.recv(1024)
     conn.send(b'HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n0123456789')
+    conn.close()
+    server.close()
+
+
+def echoing_server(port_holder: list[int]) -> None:
+    """Echo the raw request (request line, headers and body) back in the response body."""
+    server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    server.bind(('::', 0))
+    port_holder[0] = server.getsockname()[1]
+    server.listen(1)
+
+    conn, _ = server.accept()
+    conn.settimeout(5)
+    request = b''
+    while not request.endswith(b'0\r\n\r\n'):
+        request += conn.recv(1024)
+    conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
     conn.close()
     server.close()
 
@@ -453,6 +473,23 @@ class TestRequestBody:
         )
         assert response.status_code == 200
         assert response.json()['data'] == '{"Impit-Test":"foořžš"}'
+
+    def test_passing_iterator_body(self, browser: Browser) -> None:
+        port_holder = [0]
+        thread = threading.Thread(target=echoing_server, args=(port_holder,))
+        thread.start()
+        time.sleep(0.1)
+
+        def chunks() -> Iterator[bytes]:
+            yield b'{"Impit-Test":'
+            yield b'"foo"}'
+
+        impit = Client(browser=browser)
+
+        response = impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=5)
+        assert 'transfer-encoding: chunked' in response.text.lower()
+        assert response.text.endswith('E\r\n{"Impit-Test":\r\n6\r\n"foo"}\r\n0\r\n\r\n')
+        thread.join()
 
     def test_passing_string_body_in_data(self, browser: Browser) -> None:
         impit = Client(browser=browser)

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -15,6 +15,7 @@ from impit import (
     Client,
     ConnectTimeout,
     Cookies,
+    HTTPError,
     ReadTimeout,
     RemoteProtocolError,
     StreamClosed,
@@ -518,6 +519,13 @@ class TestRequestBody:
 
         assert sent_before_next_chunk == [True], 'the whole body was read before the request was sent'
         assert response.text.endswith('5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n')
+
+    @pytest.mark.parametrize('body', [{'Impit-Test': 1}, 42])
+    def test_unsupported_body_type(self, browser: Browser, body: object) -> None:
+        impit = Client(browser=browser)
+
+        with pytest.raises((TypeError, HTTPError), match='Unsupported data type'):
+            impit.post('http://localhost:1/', content=body, timeout=5)  # type: ignore[arg-type]
 
     def test_passing_string_body_in_data(self, browser: Browser) -> None:
         impit = Client(browser=browser)

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import socket
 import threading
@@ -59,8 +60,11 @@ def truncating_server(port_holder: list[int]) -> None:
     server.close()
 
 
-def echoing_server(port_holder: list[int]) -> None:
-    """Echo the raw request (request line, headers and body) back in the response body."""
+def echoing_server(port_holder: list[int], body_started: threading.Event | None = None) -> None:
+    """Echo the raw request (request line, headers and body) back in the response body.
+
+    `body_started` is set as soon as the first body byte arrives, before the request is complete.
+    """
     server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
@@ -71,8 +75,11 @@ def echoing_server(port_holder: list[int]) -> None:
     conn, _ = server.accept()
     conn.settimeout(5)
     request = b''
-    while not request.endswith(b'0\r\n\r\n'):
-        request += conn.recv(1024)
+    with contextlib.suppress(TimeoutError):
+        while not request.endswith(b'0\r\n\r\n'):
+            request += conn.recv(1024)
+            if body_started is not None and request.partition(b'\r\n\r\n')[2]:
+                body_started.set()
     conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
     conn.close()
     server.close()
@@ -489,6 +496,27 @@ class TestRequestBody:
         response = impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=5)
         assert 'transfer-encoding: chunked' in response.text.lower()
         assert response.text.endswith('E\r\n{"Impit-Test":\r\n6\r\n"foo"}\r\n0\r\n\r\n')
+        thread.join()
+
+    def test_iterator_body_is_not_buffered(self, browser: Browser) -> None:
+        port_holder = [0]
+        body_started = threading.Event()
+        thread = threading.Thread(target=echoing_server, args=(port_holder, body_started))
+        thread.start()
+        time.sleep(0.1)
+
+        sent_before_next_chunk = []
+
+        def chunks() -> Iterator[bytes]:
+            yield b'first'
+            sent_before_next_chunk.append(body_started.wait(5))
+            yield b'second'
+
+        impit = Client(browser=browser)
+
+        response = impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=10)
+        assert sent_before_next_chunk == [True], 'the whole body was read before the request was sent'
+        assert response.text.endswith('5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n')
         thread.join()
 
     def test_passing_string_body_in_data(self, browser: Browser) -> None:

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -487,6 +487,15 @@ class TestRequestBody:
         assert sent_before_next_chunk == [True], 'the whole body was read before the request was sent'
         assert response.text.endswith('5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n')
 
+    def test_passing_str_body(self, browser: Browser) -> None:
+        impit = Client(browser=browser)
+
+        with echoing_server() as port:
+            response = impit.post(f'http://localhost:{port}/', content='Impit-Test: foořžš', timeout=5)
+
+        assert 'content-length: 21' in response.text.lower()
+        assert response.text.endswith('Impit-Test: foořžš')
+
     @pytest.mark.parametrize('body', [{'Impit-Test': 1}, 42])
     def test_unsupported_body_type(self, browser: Browser, body: object) -> None:
         impit = Client(browser=browser)

--- a/impit-python/test/basic_client_test.py
+++ b/impit-python/test/basic_client_test.py
@@ -60,8 +60,9 @@ def truncating_server(port_holder: list[int]) -> None:
     server.close()
 
 
-def echoing_server(port_holder: list[int], body_started: threading.Event | None = None) -> None:
-    """Echo the raw request (request line, headers and body) back in the response body.
+@contextlib.contextmanager
+def echoing_server(body_started: threading.Event | None = None) -> Iterator[int]:
+    """Serve a single request, echoing it back in the response body, and yield the port to call.
 
     `body_started` is set as soon as the first body byte arrives, before the request is complete.
     """
@@ -69,20 +70,27 @@ def echoing_server(port_holder: list[int], body_started: threading.Event | None 
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
     server.bind(('::', 0))
-    port_holder[0] = server.getsockname()[1]
     server.listen(1)
 
-    conn, _ = server.accept()
-    conn.settimeout(5)
-    request = b''
-    with contextlib.suppress(TimeoutError):
-        while not request.endswith(b'0\r\n\r\n'):
-            request += conn.recv(1024)
-            if body_started is not None and request.partition(b'\r\n\r\n')[2]:
-                body_started.set()
-    conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
-    conn.close()
-    server.close()
+    def echo() -> None:
+        conn, _ = server.accept()
+        conn.settimeout(5)
+        request = b''
+        with contextlib.suppress(TimeoutError):
+            while not request.endswith(b'0\r\n\r\n'):
+                request += conn.recv(1024)
+                if body_started is not None and request.partition(b'\r\n\r\n')[2]:
+                    body_started.set()
+        conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
+        conn.close()
+
+    thread = threading.Thread(target=echo, daemon=True)
+    thread.start()
+    try:
+        yield server.getsockname()[1]
+    finally:
+        thread.join(5)
+        server.close()
 
 
 @pytest.mark.parametrize(
@@ -482,29 +490,20 @@ class TestRequestBody:
         assert response.json()['data'] == '{"Impit-Test":"foořžš"}'
 
     def test_passing_iterator_body(self, browser: Browser) -> None:
-        port_holder = [0]
-        thread = threading.Thread(target=echoing_server, args=(port_holder,))
-        thread.start()
-        time.sleep(0.1)
-
         def chunks() -> Iterator[bytes]:
             yield b'{"Impit-Test":'
             yield b'"foo"}'
 
         impit = Client(browser=browser)
 
-        response = impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=5)
+        with echoing_server() as port:
+            response = impit.post(f'http://localhost:{port}/', content=chunks(), timeout=5)
+
         assert 'transfer-encoding: chunked' in response.text.lower()
         assert response.text.endswith('E\r\n{"Impit-Test":\r\n6\r\n"foo"}\r\n0\r\n\r\n')
-        thread.join()
 
     def test_iterator_body_is_not_buffered(self, browser: Browser) -> None:
-        port_holder = [0]
         body_started = threading.Event()
-        thread = threading.Thread(target=echoing_server, args=(port_holder, body_started))
-        thread.start()
-        time.sleep(0.1)
-
         sent_before_next_chunk = []
 
         def chunks() -> Iterator[bytes]:
@@ -514,10 +513,11 @@ class TestRequestBody:
 
         impit = Client(browser=browser)
 
-        response = impit.post(f'http://localhost:{port_holder[0]}/', content=chunks(), timeout=10)
+        with echoing_server(body_started) as port:
+            response = impit.post(f'http://localhost:{port}/', content=chunks(), timeout=10)
+
         assert sent_before_next_chunk == [True], 'the whole body was read before the request was sent'
         assert response.text.endswith('5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n')
-        thread.join()
 
     def test_passing_string_body_in_data(self, browser: Browser) -> None:
         impit = Client(browser=browser)

--- a/impit-python/test/servers.py
+++ b/impit-python/test/servers.py
@@ -1,0 +1,44 @@
+"""Local HTTP servers used by the tests."""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@contextlib.contextmanager
+def echoing_server(body_started: threading.Event | None = None) -> Iterator[int]:
+    """Serve a single request, echoing it back in the response body, and yield the port to call.
+
+    `body_started` is set as soon as the first body byte arrives, before the request is complete.
+    """
+    server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    server.bind(('::', 0))
+    server.listen(1)
+
+    def echo() -> None:
+        conn, _ = server.accept()
+        conn.settimeout(5)
+        request = b''
+        with contextlib.suppress(TimeoutError):
+            while not request.endswith(b'0\r\n\r\n'):
+                request += conn.recv(1024)
+                if body_started is not None and request.partition(b'\r\n\r\n')[2]:
+                    body_started.set()
+        conn.send(f'HTTP/1.1 200 OK\r\nContent-Length: {len(request)}\r\n\r\n'.encode() + request)
+        conn.close()
+
+    thread = threading.Thread(target=echo, daemon=True)
+    thread.start()
+    try:
+        yield server.getsockname()[1]
+    finally:
+        thread.join(5)
+        server.close()

--- a/impit-python/test/servers.py
+++ b/impit-python/test/servers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import re
 import socket
 import threading
 from typing import TYPE_CHECKING
@@ -23,12 +24,21 @@ def echoing_server(body_started: threading.Event | None = None) -> Iterator[int]
     server.bind(('::', 0))
     server.listen(1)
 
+    def received_whole_body(request: bytes) -> bool:
+        head, separator, body = request.partition(b'\r\n\r\n')
+        if not separator:
+            return False
+        content_length = re.search(rb'content-length: *(\d+)', head, re.IGNORECASE)
+        if content_length is None:
+            return request.endswith(b'0\r\n\r\n')
+        return len(body) >= int(content_length[1])
+
     def echo() -> None:
         conn, _ = server.accept()
         conn.settimeout(5)
         request = b''
         with contextlib.suppress(TimeoutError):
-            while not request.endswith(b'0\r\n\r\n'):
+            while not received_whole_body(request):
                 request += conn.recv(1024)
                 if body_started is not None and request.partition(b'\r\n\r\n')[2]:
                     body_started.set()


### PR DESCRIPTION
Lets `content=` take a sync or async iterable of byte chunks and streams it into the request instead of buffering it; stacked on #514.

Related: #513