### PR TITLE
perf: optimize release builds for speed instead of size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ hyper-util = { git = "https://github.com/apify/hyper-util", rev="9b7795dfd7158fc
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.
-opt-level = "z"  # Optimize for size.
+opt-level = 3
 lto = true
 codegen-units = 1


### PR DESCRIPTION
The size-first profile was added for `impit-cli`, removed in #405; `opt-level = 3` gains 11-26% throughput in the Python bindings for about 1 MB of wheel size.