### PR TITLE
chore: stop renovate churn on self-published impit-* packages

### DIFF
--- a/impit-node/CHANGELOG.md
+++ b/impit-node/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 
 
+## js-0.14.4 - 2026-08-24
+
+#### Features
+
+- Add `chrome151` browser fingerprint (#510)
+  - Adds a `chrome151` fingerprint. Closes #508.  Relative to `chrome142` the only wire-level TLS difference is that Chrome now leads its `signature_algorithms` list with the three ML-DSA codepoints `0x0904`/`0x0905`/`0x0906`, which is the entire reason `chrome142` produces a different JA4 from current Chrome. Ciphers, extensions, key exchange groups, ALPN, ALPS, ECH and the HTTP/2 settings are unchanged.
+
+
+- Support streaming request bodies (#514)
+  - Adds `ImpitBody`, letting the core crate stream request bodies into reqwest instead of always buffering them; bindings support comes in follow-ups.
+
+
+- Stream request bodies (#516)
+  - Streamed bodies (`ReadableStream`, Node streams, async iterables) are now passed to the native layer as a pull callback, so they reach the connection as they are produced instead of being buffered up front.  Stacked on #514. Related: #513
+
+
+
 ## js-0.14.3 - 2026-07-14
 
 #### Bug Fixes

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -57,12 +57,12 @@
   "description": "Impit for JavaScript",
   "optionalDependencies": {
     "impit-darwin-x64": "0.14.3",
-    "impit-darwin-arm64": "0.14.4",
+    "impit-darwin-arm64": "0.14.3",
     "impit-win32-x64-msvc": "0.14.3",
     "impit-win32-arm64-msvc": "0.14.3",
     "impit-linux-x64-gnu": "0.14.3",
     "impit-linux-x64-musl": "0.14.3",
-    "impit-linux-arm64-gnu": "0.14.4",
+    "impit-linux-arm64-gnu": "0.14.3",
     "impit-linux-arm64-musl": "0.14.3"
   }
 }

--- a/impit-node/package.json
+++ b/impit-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "impit",
   "homepage": "https://apify.github.io/impit/js",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "main": "index.wrapper.js",
   "types": "index.d.ts",
   "napi": {
@@ -56,13 +56,13 @@
   "packageManager": "pnpm@10.24.0",
   "description": "Impit for JavaScript",
   "optionalDependencies": {
-    "impit-darwin-x64": "0.14.3",
-    "impit-darwin-arm64": "0.14.3",
-    "impit-win32-x64-msvc": "0.14.3",
-    "impit-win32-arm64-msvc": "0.14.3",
-    "impit-linux-x64-gnu": "0.14.3",
-    "impit-linux-x64-musl": "0.14.3",
-    "impit-linux-arm64-gnu": "0.14.3",
-    "impit-linux-arm64-musl": "0.14.3"
+    "impit-darwin-x64": "0.14.4",
+    "impit-darwin-arm64": "0.14.4",
+    "impit-win32-x64-msvc": "0.14.4",
+    "impit-win32-arm64-msvc": "0.14.4",
+    "impit-linux-x64-gnu": "0.14.4",
+    "impit-linux-x64-musl": "0.14.4",
+    "impit-linux-arm64-gnu": "0.14.4",
+    "impit-linux-arm64-musl": "0.14.4"
   }
 }

--- a/impit-node/pnpm-lock.yaml
+++ b/impit-node/pnpm-lock.yaml
@@ -46,14 +46,14 @@ importers:
         version: 4.1.4(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(yaml@2.8.3))
     optionalDependencies:
       impit-darwin-arm64:
-        specifier: 0.14.4
-        version: 0.14.4
+        specifier: 0.14.3
+        version: 0.14.3
       impit-darwin-x64:
         specifier: 0.14.3
         version: 0.14.3
       impit-linux-arm64-gnu:
-        specifier: 0.14.4
-        version: 0.14.4
+        specifier: 0.14.3
+        version: 0.14.3
       impit-linux-arm64-musl:
         specifier: 0.14.3
         version: 0.14.3
@@ -1056,8 +1056,8 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  impit-darwin-arm64@0.14.4:
-    resolution: {integrity: sha512-i9fkPXXCB/1qBTGIlS26Z2krmE0wk/1UUlDUFeE1bMtihoUIe8TbeslSnx6pgaSY5ai9H0seUAgS9D4i66Kscg==}
+  impit-darwin-arm64@0.14.3:
+    resolution: {integrity: sha512-kMoQB+CR+a954pnhe4kf1O2RyJCsqGRE95jIXfgqNOiIMS5O1z0cOMzG/sohJk/nodZVSJ5VdWEV4BKhRWPFSA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1068,8 +1068,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  impit-linux-arm64-gnu@0.14.4:
-    resolution: {integrity: sha512-9VVb905sNSPh0dF2sDFbbjSz5JqXCoMPxTery77PyqMCEuxybtW+Yv3U1tCM+CFKSuC39wXmueW+FLwOCS+zIw==}
+  impit-linux-arm64-gnu@0.14.3:
+    resolution: {integrity: sha512-+mwta93S6Ndfpca3DDblvrqV1g8Bg6gZFOlEiJHfGJZpiUIQE+A/Pjg2e+inV+WrTtlnLsvff8lgwFvkIGnRug==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2457,13 +2457,13 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  impit-darwin-arm64@0.14.4:
+  impit-darwin-arm64@0.14.3:
     optional: true
 
   impit-darwin-x64@0.14.3:
     optional: true
 
-  impit-linux-arm64-gnu@0.14.4:
+  impit-linux-arm64-gnu@0.14.3:
     optional: true
 
   impit-linux-arm64-musl@0.14.3:

--- a/impit-node/pnpm-lock.yaml
+++ b/impit-node/pnpm-lock.yaml
@@ -46,29 +46,29 @@ importers:
         version: 4.1.4(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(yaml@2.8.3))
     optionalDependencies:
       impit-darwin-arm64:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.14.4
+        version: 0.14.4
       impit-darwin-x64:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.14.4
+        version: 0.14.4
       impit-linux-arm64-gnu:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.14.4
+        version: 0.14.4
       impit-linux-arm64-musl:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.14.4
+        version: 0.14.4
       impit-linux-x64-gnu:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.14.4
+        version: 0.14.4
       impit-linux-x64-musl:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.14.4
+        version: 0.14.4
       impit-win32-arm64-msvc:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.14.4
+        version: 0.14.4
       impit-win32-x64-msvc:
-        specifier: 0.14.3
-        version: 0.14.3
+        specifier: 0.14.4
+        version: 0.14.4
 
 packages:
 
@@ -1056,54 +1056,54 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  impit-darwin-arm64@0.14.3:
-    resolution: {integrity: sha512-kMoQB+CR+a954pnhe4kf1O2RyJCsqGRE95jIXfgqNOiIMS5O1z0cOMzG/sohJk/nodZVSJ5VdWEV4BKhRWPFSA==}
+  impit-darwin-arm64@0.14.4:
+    resolution: {integrity: sha512-i9fkPXXCB/1qBTGIlS26Z2krmE0wk/1UUlDUFeE1bMtihoUIe8TbeslSnx6pgaSY5ai9H0seUAgS9D4i66Kscg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  impit-darwin-x64@0.14.3:
-    resolution: {integrity: sha512-ft9+kjz1pR8H5xbbf5U1EgwaaIea5iXHxBf2Q3NoinPpiV7KgyzYSr83pCSrAY6evWk+smG9shHgzhQtgbj1Rg==}
+  impit-darwin-x64@0.14.4:
+    resolution: {integrity: sha512-p+W0enCZDCsnSwEWOMImpHq71jmVR7J9CjYvqgiFtQD3W+rQb7ilFLYYRalQ0rmrrH8imLRm2skG6V7YQkPwOg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  impit-linux-arm64-gnu@0.14.3:
-    resolution: {integrity: sha512-+mwta93S6Ndfpca3DDblvrqV1g8Bg6gZFOlEiJHfGJZpiUIQE+A/Pjg2e+inV+WrTtlnLsvff8lgwFvkIGnRug==}
+  impit-linux-arm64-gnu@0.14.4:
+    resolution: {integrity: sha512-9VVb905sNSPh0dF2sDFbbjSz5JqXCoMPxTery77PyqMCEuxybtW+Yv3U1tCM+CFKSuC39wXmueW+FLwOCS+zIw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  impit-linux-arm64-musl@0.14.3:
-    resolution: {integrity: sha512-wYhfH1J8laWkpSN2SAFCKx9npY4vXrk23ex+tOzTGf2xBBqIhpMUff2wa6dOFb0or6EhZHBssoRf0HK3h/htXQ==}
+  impit-linux-arm64-musl@0.14.4:
+    resolution: {integrity: sha512-PajwrCPCWPey4wjLSWSVFS/mRQXbh8WVrxXdgo6Ej530dyplxIiqcDh0Gr9fWYPriOC8pkcOpRqQ4O+1mH1xfQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  impit-linux-x64-gnu@0.14.3:
-    resolution: {integrity: sha512-hAYnutJDGQO5bPvTPKBBFkHgbB7QL7QLDse8c4s21VSzC/EqGliSS3UqR5ZUUwaFdm3t8DJsXOr+gboAUwDR7w==}
+  impit-linux-x64-gnu@0.14.4:
+    resolution: {integrity: sha512-Ly8CweOZ9Qj6BZNhvglJMo56i7tCF7Nw33OdXLZLZRxnBzxd2kI/LXpFsd1LiMkTDaiuLvqLGo7ZpxVt08LdwA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  impit-linux-x64-musl@0.14.3:
-    resolution: {integrity: sha512-wXBeHiqCjuyqxg4u5eY4OBNVzsS4Karz/ms/0mjB8aqVZLNER1NaUTeE4J3eZCdytFaJRaAeQvKTH8HfjpPsQg==}
+  impit-linux-x64-musl@0.14.4:
+    resolution: {integrity: sha512-dS9wj2phkB+o8OFdWBIFYx23ExH+pcsFMiXmoOwRVdDfUX9reZTmZL4KaiPuhSEBysN/wd46dxB/OzNbnn5hnQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  impit-win32-arm64-msvc@0.14.3:
-    resolution: {integrity: sha512-XiF8MYpm4tF8TMbtsWrcEDDs6NxRNeirfiHM/AyKcr2jiN34hZwbZDM0EseD30PDwb2Pny2JWB+zTxpE1P5CZg==}
+  impit-win32-arm64-msvc@0.14.4:
+    resolution: {integrity: sha512-Nga0z+Hmp/HmxEKX0jv1wy2vaT4J44nE6+Z+CNZvvyVWiodWCG9+FvVn4McivgXix7UerspeyPvc174QBHwXEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  impit-win32-x64-msvc@0.14.3:
-    resolution: {integrity: sha512-HIaLSpU5SGVx3UDH/R3ZaGMURVgyRVjmalqXj65ABxVUqfXiBo1t5ZObDPPjqvLT3klPnrya1+xF1DQ4dfT+og==}
+  impit-win32-x64-msvc@0.14.4:
+    resolution: {integrity: sha512-v15fn/kcjLEzALB4z+VWTeG1UrtqZQq9n2HNsRUfUgfcgzM1i+KKtKP2RCJ1Fg1YeojQ7B6XGhRtpVVTjh8u+A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2457,28 +2457,28 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  impit-darwin-arm64@0.14.3:
+  impit-darwin-arm64@0.14.4:
     optional: true
 
-  impit-darwin-x64@0.14.3:
+  impit-darwin-x64@0.14.4:
     optional: true
 
-  impit-linux-arm64-gnu@0.14.3:
+  impit-linux-arm64-gnu@0.14.4:
     optional: true
 
-  impit-linux-arm64-musl@0.14.3:
+  impit-linux-arm64-musl@0.14.4:
     optional: true
 
-  impit-linux-x64-gnu@0.14.3:
+  impit-linux-x64-gnu@0.14.4:
     optional: true
 
-  impit-linux-x64-musl@0.14.3:
+  impit-linux-x64-musl@0.14.4:
     optional: true
 
-  impit-win32-arm64-msvc@0.14.3:
+  impit-win32-arm64-msvc@0.14.4:
     optional: true
 
-  impit-win32-x64-msvc@0.14.3:
+  impit-win32-x64-msvc@0.14.4:
     optional: true
 
   inherits@2.0.4: {}

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,10 @@
 			"automergeType": "branch"
 		},
 		{
+			"matchPackageNames": ["impit-*"],
+			"enabled": false
+		},
+		{
 			"matchPackageNames": ["@apify/*", "@crawlee/*", "apify-client", "apify", "crawlee", "got-scraping"],
 			"minimumReleaseAge": "0 days"
 		}

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
 		{
 			"matchUpdateTypes": ["patch", "minor"],
 			"matchCurrentVersion": "!/^0/",
-			"groupName": "patch/minor dependencies",
+			"groupName": "non-major dependencies",
 			"groupSlug": "all-non-major",
 			"automerge": true,
 			"automergeType": "branch"
@@ -27,7 +27,7 @@
 		{
 			"matchUpdateTypes": ["patch"],
 			"matchCurrentVersion": "/^0/",
-			"groupName": "patch/minor dependencies",
+			"groupName": "non-major dependencies",
 			"groupSlug": "all-non-major",
 			"automerge": true,
 			"automergeType": "branch"

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,14 @@
 			"automergeType": "branch"
 		},
 		{
+			"matchUpdateTypes": ["patch"],
+			"matchCurrentVersion": "/^0/",
+			"groupName": "patch/minor dependencies",
+			"groupSlug": "all-non-major",
+			"automerge": true,
+			"automergeType": "branch"
+		},
+		{
 			"matchPackageNames": ["@apify/*", "@crawlee/*", "apify-client", "apify", "crawlee", "got-scraping"],
 			"minimumReleaseAge": "0 days"
 		}


### PR DESCRIPTION
The `impit-*` platform packages in `impit-node`'s `optionalDependencies` are our own napi-rs binary packages, published by the release workflow and version-synced by `pnpm copy-version` at release time. Renovate treats them as third-party deps and opens one PR per package after every release (see #525 to #528), and merging those one by one causes conflicts.

Renovate changes:

- `impit-*` packages are ignored entirely; the release workflow owns those versions.
- 0.x patch updates of genuine third-party deps join the existing non-major group instead of being excluded by the `!/^0/` rule. 0.x minors stay separate, since those can be breaking under semver-0 conventions. The group is renamed to "non-major dependencies" so the name covers everything in it.

This PR also finishes the parts of the 0.14.4 release that the release run left behind (its commit-back to master was rejected by branch rules): the loader `version` and `optionalDependencies` are bumped to 0.14.4 to match npm, and the missing 0.14.4 changelog entry is added, generated with git-cliff using the same arguments as the workflow. The `js-0.14.4` tag and the GitHub release were created separately, since those don't live in the repo.
