### PR TITLE
fix(http3): update cached Alt-Svc support

### DIFF
--- a/impit/src/http3.rs
+++ b/impit/src/http3.rs
@@ -78,10 +78,25 @@ impl H3Engine {
 
     pub async fn set_h3_support(&self, host: &String, supports_h3: bool) {
         let mut cache = self.h3_alt_svc.write().await;
-        if cache.contains_key(host) {
-            return;
-        }
-
         cache.insert(host.to_owned(), supports_h3);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn alt_svc_discovery_updates_cached_h3_support() {
+        let engine = H3Engine::init().await;
+        let host = "example.com".to_string();
+        let other_host = "other.example.com".to_string();
+
+        engine.set_h3_support(&host, false).await;
+        engine.set_h3_support(&other_host, false).await;
+        engine.set_h3_support(&host, true).await;
+
+        assert!(engine.host_supports_h3(&host).await);
+        assert!(!engine.host_supports_h3(&other_host).await);
     }
 }


### PR DESCRIPTION
## Why

Alt-Svc `h3` discovery first records a host as not h3-capable, then needs to upgrade that cached value when the response advertises HTTP/3.

## Verification

- Before: `cargo test -p impit http3::tests::alt_svc_discovery_updates_cached_h3_support -- --exact` failed because the cached `false` value was retained.
- After: `cargo test -p impit` passes, including the cache-upgrade regression test.
- `cargo fmt --check`
- `cargo clippy -p impit --all-targets -- -D warnings`

Fixes #471
