### PR TITLE
ci(node): serialize the binding-test matrix to stop tripping httpbin's rate limit

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -157,6 +157,8 @@ jobs:
       - build
     strategy:
       fail-fast: false
+      # Serialized: all binding test jobs share one httpbin instance capped at 70 req/s.
+      max-parallel: 1
       matrix:
         settings:
           - host: macos-latest
@@ -209,6 +211,8 @@ jobs:
       - build
     strategy:
       fail-fast: false
+      # Serialized: all binding test jobs share one httpbin instance capped at 70 req/s.
+      max-parallel: 1
       matrix:
         node:
           - '20'
@@ -244,6 +248,8 @@ jobs:
       - build
     strategy:
       fail-fast: false
+      # Serialized: all binding test jobs share one httpbin instance capped at 70 req/s.
+      max-parallel: 1
       matrix:
         node:
           - '20'
@@ -282,6 +288,8 @@ jobs:
       - build
     strategy:
       fail-fast: false
+      # Serialized: all binding test jobs share one httpbin instance capped at 70 req/s.
+      max-parallel: 1
       matrix:
         node:
           - '20'
@@ -313,6 +321,8 @@ jobs:
       - build
     strategy:
       fail-fast: false
+      # Serialized: all binding test jobs share one httpbin instance capped at 70 req/s.
+      max-parallel: 1
       matrix:
         node:
           - '20'


### PR DESCRIPTION
The node binding tests all hit one httpbin instance capped at 70 req/s, and the full matrix running at once overran that, so several open PRs (#542, #543, #544) are failing on random rate-limited assertions.